### PR TITLE
Add help modal with player guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --host"
+    "preview": "vite preview --host",
+	"deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -113,6 +113,7 @@ const FarmGame = () => {
   const [showStats, setShowStats] = useState(false);
   const [showSaveMenu, setShowSaveMenu] = useState(false);
   const [showLoadMenu, setShowLoadMenu] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   const [notifications, setNotifications] = useState([]);
   
   // 新功能狀態
@@ -697,6 +698,10 @@ const FarmGame = () => {
                   className="bg-yellow-500 hover:bg-yellow-600 text-white px-2 py-1 rounded text-xs transition-colors">
             ⚡ 快存
           </button>
+          <button onClick={() => setShowHelp(true)}
+                  className="bg-indigo-500 hover:bg-indigo-600 text-white px-2 py-1 rounded text-xs transition-colors">
+            📖 說明
+          </button>
           <div className="flex items-center space-x-1 ml-4">
             {getTimeIcon()}
             <span>{time}:00</span>
@@ -931,6 +936,95 @@ const FarmGame = () => {
           </div>
         </div>
       </div>
+
+      {/* 說明書模態框 */}
+      {showHelp && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 max-w-3xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-bold flex items-center text-green-700">
+                <span className="text-2xl mr-2">📖</span>
+                玩家說明書
+              </h2>
+              <button onClick={() => setShowHelp(false)} className="text-gray-500 hover:text-gray-700">✕</button>
+            </div>
+            <div className="space-y-6 text-sm text-gray-700 leading-relaxed">
+              <section>
+                <h3 className="font-semibold text-lg text-green-600">🎯 遊戲目標</h3>
+                <p className="mt-2">賺取金幣、升級等級，打造屬於自己的夢幻農場。每天記得照顧作物和動物，累積資源就能解鎖更多功能。</p>
+              </section>
+              <section>
+                <h3 className="font-semibold text-lg text-yellow-600">💰 金錢怎麼賺、怎麼花</h3>
+                <ul className="list-disc pl-5 space-y-1 mt-2">
+                  <li>初始資金：500 金幣。</li>
+                  <li>收入來源：收成作物、動物每日產出、完成任務或成就。</li>
+                  <li>支出項目：購買種子、動物、建築、工具，以及每天的飼料費。</li>
+                  <li>市場價格會波動，記得低買高賣，賺得更快。</li>
+                </ul>
+              </section>
+              <section>
+                <h3 className="font-semibold text-lg text-emerald-600">🌱 作物入門</h3>
+                <ul className="list-disc pl-5 space-y-1 mt-2">
+                  <li>到「種子商店」買種子，在農田空格種下會消耗體力。</li>
+                  <li>不同作物有不同成長時間，天氣與工具等級會改變速度。</li>
+                  <li>澆水、在溫室種植或擁有筒倉，都能提高售價。</li>
+                  <li>例子：玉米基準價 $50，若有澆水（+20%）又在溫室（+50%），收成價約可達 $90。</li>
+                </ul>
+              </section>
+              <section>
+                <h3 className="font-semibold text-lg text-orange-500">🐾 照顧動物</h3>
+                <ul className="list-disc pl-5 space-y-1 mt-2">
+                  <li>在「動物商店」購買，部分動物需要先蓋對應建築。</li>
+                  <li>每天餵食會扣飼料費，但能維持快樂度（最高 100）。</li>
+                  <li>快樂度越高，產出的金幣越多；建築會提供額外加成。</li>
+                </ul>
+              </section>
+              <section>
+                <h3 className="font-semibold text-lg text-blue-600">🏠 建築與工具</h3>
+                <ul className="list-disc pl-5 space-y-1 mt-2">
+                  <li>建築能提升產量或帶來特殊效果，例如溫室免受天氣影響、筒倉賣價 +10%。</li>
+                  <li>工具分四個等級，等級越高越省體力、作物長得越快。</li>
+                </ul>
+              </section>
+              <section>
+                <h3 className="font-semibold text-lg text-sky-600">⚡ 體力、天氣與季節</h3>
+                <ul className="list-disc pl-5 space-y-1 mt-2">
+                  <li>每日體力上限 100，種植、澆水等行動會消耗體力。</li>
+                  <li>雨天會自動澆水，晴天適合日照作物，雪天則要小心成長變慢。</li>
+                  <li>每 30 天進入新季節（春→夏→秋→冬），部分作物或動物在特定季節表現更好。</li>
+                </ul>
+              </section>
+              <section>
+                <h3 className="font-semibold text-lg text-purple-600">🏆 成就、任務與顧問</h3>
+                <ul className="list-disc pl-5 space-y-1 mt-2">
+                  <li>完成成就可拿到獎勵金幣，例如第一次種植、養滿 10 隻動物等。</li>
+                  <li>和 NPC（農夫老張、商人小李）對話，可接到簡單任務換獎勵。</li>
+                  <li>AI 顧問會依照天氣、金錢或體力提醒下一步策略。</li>
+                </ul>
+              </section>
+              <section>
+                <h3 className="font-semibold text-lg text-rose-600">💾 存檔小幫手</h3>
+                <ul className="list-disc pl-5 space-y-1 mt-2">
+                  <li>共有五個存檔槽位，可手動保存，也能使用⚡快存快速備份。</li>
+                  <li>支援導出與導入存檔，想備份或分享農場都沒問題。</li>
+                </ul>
+              </section>
+              <section>
+                <h3 className="font-semibold text-lg text-gray-700">✨ 新手暖心提醒</h3>
+                <ul className="list-disc pl-5 space-y-1 mt-2">
+                  <li>先從便宜的作物與動物開始，穩定現金流後再投資大型建築。</li>
+                  <li>體力不足就先休息或升級工具，避免行動被卡住。</li>
+                  <li>時常查看市場價格與天氣，掌握好時機更容易發大財！</li>
+                </ul>
+              </section>
+            </div>
+            <button onClick={() => setShowHelp(false)}
+                    className="mt-6 w-full bg-indigo-500 hover:bg-indigo-600 text-white py-2 px-4 rounded transition-colors">
+              了解了！
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* 種子商店模態框 */}
       {showShop && (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,72 +1,10 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target } from 'lucide-react';
-
-const CROPS = {
-  carrot: { name: '胡蘿蔔', price: 10, growTime: 5, sellPrice: 25, emoji: '🥕', weatherBonus: { sunny: 1.2, rainy: 1.0, snow: 0.8 } },
-  corn: { name: '玉米', price: 20, growTime: 8, sellPrice: 50, emoji: '🌽', weatherBonus: { sunny: 1.3, rainy: 1.1, snow: 0.6 } },
-  tomato: { name: '番茄', price: 15, growTime: 6, sellPrice: 35, emoji: '🍅', weatherBonus: { sunny: 1.4, rainy: 0.9, snow: 0.5 } },
-  wheat: { name: '小麥', price: 8, growTime: 4, sellPrice: 20, emoji: '🌾', weatherBonus: { sunny: 1.1, rainy: 1.2, snow: 0.9 } },
-  potato: { name: '馬鈴薯', price: 12, growTime: 7, sellPrice: 30, emoji: '🥔', weatherBonus: { sunny: 1.0, rainy: 1.3, snow: 1.1 } },
-  strawberry: { name: '草莓', price: 25, growTime: 10, sellPrice: 60, emoji: '🍓', weatherBonus: { sunny: 1.2, rainy: 0.8, snow: 0.4 } }
-};
-
-const ANIMALS = {
-  dog: { name: '狗狗', price: 200, happiness: 50, emoji: '🐕', foodCost: 5, income: 8, shelter: 'dogHouse' },
-  cat: { name: '貓咪', price: 150, happiness: 60, emoji: '🐱', foodCost: 3, income: 5, shelter: 'catHouse' },
-  chicken: { name: '雞', price: 100, happiness: 40, emoji: '🐔', foodCost: 2, income: 12, shelter: 'chickenCoop' },
-  cow: { name: '牛', price: 500, happiness: 30, emoji: '🐄', foodCost: 10, income: 25, shelter: 'barn' },
-  pig: { name: '豬', price: 300, happiness: 45, emoji: '🐷', foodCost: 8, income: 18, shelter: 'pigPen' },
-  sheep: { name: '羊', price: 250, happiness: 40, emoji: '🐑', foodCost: 6, income: 15, shelter: 'barn' },
-  duck: { name: '鴨子', price: 120, happiness: 55, emoji: '🦆', foodCost: 3, income: 10, shelter: 'pond' },
-  rabbit: { name: '兔子', price: 80, happiness: 70, emoji: '🐰', foodCost: 2, income: 6, shelter: 'rabbitHutch' }
-};
-
-const BUILDINGS = {
-  barn: { name: '穀倉', price: 1000, emoji: '🏚️', description: '容納牛羊，提升產量', boost: 1.2 },
-  chickenCoop: { name: '雞舍', price: 500, emoji: '🏠', description: '專門養雞，提升產蛋率', boost: 1.3 },
-  dogHouse: { name: '狗屋', price: 300, emoji: '🏘️', description: '狗狗的溫馨小窩', boost: 1.1 },
-  catHouse: { name: '貓屋', price: 250, emoji: '🏡', description: '貓咪的舒適居所', boost: 1.1 },
-  pigPen: { name: '豬圈', price: 400, emoji: '🏗️', description: '豬豬的泥土樂園', boost: 1.2 },
-  pond: { name: '池塘', price: 600, emoji: '🌊', description: '水鳥的天堂', boost: 1.3 },
-  rabbitHutch: { name: '兔籠', price: 200, emoji: '📦', description: '兔子的安全小屋', boost: 1.2 },
-  greenhouse: { name: '溫室', price: 2000, emoji: '🏢', description: '不受天氣影響的種植空間', boost: 1.5 },
-  silo: { name: '筒倉', price: 800, emoji: '🗼', description: '儲存更多作物', boost: 1.0 },
-  windmill: { name: '風車', price: 1500, emoji: '🌪️', description: '產生額外收入', boost: 1.0 },
-  well: { name: '水井', price: 400, emoji: '🕳️', description: '無限澆水，節省體力', boost: 1.0 }
-};
-
-const TOOLS = {
-  basic: { name: '基本工具', energyReduction: 0, speedBoost: 1, price: 0 },
-  iron: { name: '鐵製工具', energyReduction: 2, speedBoost: 1.2, price: 500 },
-  steel: { name: '鋼製工具', energyReduction: 4, speedBoost: 1.5, price: 1200 },
-  magic: { name: '魔法工具', energyReduction: 6, speedBoost: 2, price: 3000 }
-};
-
-const ACHIEVEMENTS = [
-  { id: 'firstPlant', name: '初次種植', description: '種下第一株作物', reward: 100, icon: '🌱' },
-  { id: 'richFarmer', name: '富豪農夫', description: '擁有10000金幣', reward: 500, icon: '💰' },
-  { id: 'animalLover', name: '動物愛好者', description: '擁有10隻動物', reward: 300, icon: '🐾' },
-  { id: 'builder', name: '建築大師', description: '建造5個建築', reward: 800, icon: '🏗️' },
-  { id: 'levelUp', name: '經驗老手', description: '達到等級10', reward: 1000, icon: '⭐' },
-  { id: 'weatherMaster', name: '天氣專家', description: '在所有天氣下收成作物', reward: 600, icon: '🌦️' }
-];
-
-const NPCS = [
-  { 
-    name: '農夫老張', 
-    emoji: '👨‍🌾', 
-    dialogue: ['今天天氣真好呢！', '記得給作物澆水哦！', '我這裡有些好種子...'],
-    quests: [{ type: 'plant', target: 'carrot', count: 5, reward: 200 }]
-  },
-  {
-    name: '商人小李',
-    emoji: '👨‍💼',
-    dialogue: ['生意興隆！', '需要什麼嗎？', '我有特價商品！'],
-    quests: [{ type: 'sell', target: 'tomato', count: 10, reward: 300 }]
-  }
-];
-
-const WEATHER_TYPES = ['sunny', 'rainy', 'cloudy', 'storm', 'snow'];
+import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS } from './game/data/GameCatalog';
+import { GameFormatter } from './game/utils/GameFormatter';
+import { GameEngine } from './game/engine/GameEngine';
+import { SaveManager } from './game/engine/SaveManager';
+import { NotificationCenter } from './game/engine/NotificationCenter';
 
 const FarmGame = () => {
   // 基本狀態
@@ -115,6 +53,11 @@ const FarmGame = () => {
   const [showLoadMenu, setShowLoadMenu] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [notifications, setNotifications] = useState([]);
+
+  const notificationCenter = useMemo(() => new NotificationCenter(setNotifications), []);
+  const addNotification = useCallback((message) => {
+    notificationCenter.push(message);
+  }, [notificationCenter]);
   
   // 新功能狀態
   const [completedAchievements, setCompletedAchievements] = useState(new Set());
@@ -134,171 +77,109 @@ const FarmGame = () => {
   const [saveData, setSaveData] = useState('');
   const [loadData, setLoadData] = useState('');
 
-  const addNotification = useCallback((message) => {
-    const id = Date.now();
-    setNotifications(prev => [...prev, { id, message }]);
-    setTimeout(() => {
-      setNotifications(prev => prev.filter(n => n.id !== id));
-    }, 4000);
-  }, []);
+  const stateRef = useRef({});
 
-  // 存檔相關函數
+  stateRef.current = {
+    money,
+    energy,
+    level,
+    experience,
+    time,
+    day,
+    season,
+    weather,
+    weatherDuration,
+    inventory,
+    farm,
+    animals,
+    buildings,
+    tools,
+    completedAchievements,
+    dailyStats,
+    automation,
+    marketPrices,
+    saveSlots,
+    selectedSeed,
+    loadData,
+  };
+
+  const saveManager = useMemo(() => new SaveManager({
+    stateRef,
+    setters: {
+      setMoney,
+      setEnergy,
+      setLevel,
+      setExperience,
+      setTime,
+      setDay,
+      setSeason,
+      setWeather,
+      setWeatherDuration,
+      setInventory,
+      setFarm,
+      setAnimals,
+      setBuildings,
+      setTools,
+      setCompletedAchievements,
+      setDailyStats,
+      setAutomation,
+      setMarketPrices,
+      setSaveSlots,
+      setShowSaveMenu,
+      setShowLoadMenu,
+      setLoadData,
+      setSaveData,
+    },
+    notifier: addNotification,
+  }), [addNotification]);
+
+  const gameEngine = useMemo(() => new GameEngine({
+    stateRef,
+    setters: {
+      setMoney,
+      setSelectedSeed,
+      setShowShop,
+      setFarm,
+      setEnergy,
+      setExperience,
+      setInventory,
+      setAnimals,
+      setShowAnimalShop,
+      setBuildings,
+      setShowBuildingShop,
+      setTools,
+      setShowToolShop,
+    },
+    notifier: addNotification,
+  }), [addNotification]);
+
   const saveToSlot = useCallback((slotName) => {
-    const gameState = {
-      money,
-      energy,
-      level,
-      experience,
-      time,
-      day,
-      season,
-      weather,
-      weatherDuration,
-      inventory,
-      farm,
-      animals,
-      buildings,
-      tools,
-      completedAchievements: Array.from(completedAchievements),
-      dailyStats,
-      automation,
-      marketPrices,
-      saveTime: new Date().toISOString(),
-      version: '1.0'
-    };
-    
-    setSaveSlots(prev => ({
-      ...prev,
-      [slotName]: gameState
-    }));
-    
-    addNotification(`遊戲已保存到存檔槽 ${slotName.slice(-1)}！`);
-    setShowSaveMenu(false);
-  }, [money, energy, level, experience, time, day, season, weather, weatherDuration, inventory, farm, animals, buildings, tools, completedAchievements, dailyStats, automation, marketPrices, addNotification]);
+    saveManager.saveToSlot(slotName);
+  }, [saveManager]);
 
   const loadFromSlot = useCallback((slotName) => {
-    const gameState = saveSlots[slotName];
-    if (!gameState) {
-      addNotification('存檔槽為空！');
-      return;
-    }
-
-    try {
-      setMoney(gameState.money);
-      setEnergy(gameState.energy);
-      setLevel(gameState.level);
-      setExperience(gameState.experience);
-      setTime(gameState.time);
-      setDay(gameState.day);
-      setSeason(gameState.season);
-      setWeather(gameState.weather);
-      setWeatherDuration(gameState.weatherDuration);
-      setInventory(gameState.inventory);
-      setFarm(gameState.farm);
-      setAnimals(gameState.animals);
-      setBuildings(gameState.buildings);
-      setTools(gameState.tools);
-      setCompletedAchievements(new Set(gameState.completedAchievements || []));
-      setDailyStats(gameState.dailyStats || []);
-      setAutomation(gameState.automation || { autoWater: false, autoHarvest: false });
-      setMarketPrices(gameState.marketPrices || {});
-
-      addNotification(`存檔槽 ${slotName.slice(-1)} 載入成功！`);
-      setShowLoadMenu(false);
-    } catch (error) {
-      addNotification('載入存檔失敗！存檔可能已損壞。');
-    }
-  }, [saveSlots, addNotification]);
+    saveManager.loadFromSlot(slotName);
+  }, [saveManager]);
 
   const exportSave = useCallback(() => {
-    const gameState = {
-      money,
-      energy,
-      level,
-      experience,
-      time,
-      day,
-      season,
-      weather,
-      weatherDuration,
-      inventory,
-      farm,
-      animals,
-      buildings,
-      tools,
-      completedAchievements: Array.from(completedAchievements),
-      dailyStats,
-      automation,
-      marketPrices,
-      saveTime: new Date().toISOString(),
-      version: '1.0'
-    };
-    
-    const saveString = JSON.stringify(gameState, null, 2);
-    setSaveData(saveString);
-    addNotification('存檔數據已生成！請複製保存。');
-  }, [money, energy, level, experience, time, day, season, weather, weatherDuration, inventory, farm, animals, buildings, tools, completedAchievements, dailyStats, automation, marketPrices, addNotification]);
+    saveManager.exportSave();
+  }, [saveManager]);
 
   const importSave = useCallback(() => {
-    if (!loadData.trim()) {
-      addNotification('請先輸入存檔數據！');
-      return;
-    }
-
-    try {
-      const gameState = JSON.parse(loadData);
-      
-      // 驗證存檔格式
-      if (!gameState.version || gameState.money === undefined) {
-        throw new Error('無效的存檔格式');
-      }
-
-      setMoney(gameState.money);
-      setEnergy(gameState.energy);
-      setLevel(gameState.level);
-      setExperience(gameState.experience);
-      setTime(gameState.time);
-      setDay(gameState.day);
-      setSeason(gameState.season);
-      setWeather(gameState.weather);
-      setWeatherDuration(gameState.weatherDuration || 5);
-      setInventory(gameState.inventory);
-      setFarm(gameState.farm);
-      setAnimals(gameState.animals);
-      setBuildings(gameState.buildings);
-      setTools(gameState.tools);
-      setCompletedAchievements(new Set(gameState.completedAchievements || []));
-      setDailyStats(gameState.dailyStats || []);
-      setAutomation(gameState.automation || { autoWater: false, autoHarvest: false });
-      setMarketPrices(gameState.marketPrices || {});
-
-      addNotification('存檔載入成功！');
-      setLoadData('');
-      setShowLoadMenu(false);
-    } catch (error) {
-      addNotification('載入失敗！請檢查存檔數據格式。');
-    }
-  }, [loadData, addNotification]);
+    saveManager.importSave();
+  }, [saveManager]);
 
   const deleteSaveSlot = useCallback((slotName) => {
-    setSaveSlots(prev => ({
-      ...prev,
-      [slotName]: null
-    }));
-    addNotification(`存檔槽 ${slotName.slice(-1)} 已刪除！`);
-  }, [addNotification]);
+    saveManager.deleteSaveSlot(slotName);
+  }, [saveManager]);
 
   const quickSave = useCallback(() => {
-    saveToSlot('slot1');
-  }, [saveToSlot]);
+    saveManager.quickSave();
+  }, [saveManager]);
 
   const quickLoad = useCallback(() => {
-    if (saveSlots.slot1) {
-      loadFromSlot('slot1');
-    } else {
-      addNotification('快速存檔槽為空！');
-    }
-  }, [loadFromSlot, saveSlots.slot1, addNotification]);
+    saveManager.quickLoad();
+  }, [saveManager]);
 
   // AI顧問系統
   useEffect(() => {
@@ -384,11 +265,10 @@ const FarmGame = () => {
           setDay(prevDay => {
             const newDay = prevDay + 1;
             if (newDay % 30 === 0) {
-              const seasons = ['spring', 'summer', 'autumn', 'winter'];
-              const currentSeasonIndex = seasons.indexOf(season);
-              const nextSeason = seasons[(currentSeasonIndex + 1) % 4];
+              const currentSeasonIndex = SEASONS.indexOf(season);
+              const nextSeason = SEASONS[(currentSeasonIndex + 1) % SEASONS.length];
               setSeason(nextSeason);
-              addNotification(`🌸 季節變為 ${getSeasonName(nextSeason)}！`);
+              addNotification(`🌸 季節變為 ${GameFormatter.seasonName(nextSeason)}！`);
             }
             return newDay;
           });
@@ -427,7 +307,7 @@ const FarmGame = () => {
         if (prev <= 0) {
           const newWeather = WEATHER_TYPES[Math.floor(Math.random() * WEATHER_TYPES.length)];
           setWeather(newWeather);
-          addNotification(`天氣變為 ${getWeatherName(newWeather)} ${getWeatherIcon(newWeather)}`);
+          addNotification(`天氣變為 ${GameFormatter.weatherName(newWeather)} ${GameFormatter.weatherIcon(newWeather)}`);
           return Math.floor(Math.random() * 8) + 3;
         }
         return prev - 1;
@@ -471,152 +351,37 @@ const FarmGame = () => {
     }
   }, [experience, level, addNotification]);
 
-  const getWeatherName = (weatherType) => {
-    const names = {
-      sunny: '晴天', rainy: '雨天', cloudy: '陰天', 
-      storm: '暴風雨', snow: '雪天'
-    };
-    return names[weatherType];
-  };
+  const buySeed = useCallback((seedType) => {
+    gameEngine.buySeed(seedType);
+  }, [gameEngine]);
 
-  const getSeasonName = (seasonType) => {
-    const names = {
-      spring: '春天', summer: '夏天', autumn: '秋天', winter: '冬天'
-    };
-    return names[seasonType];
-  };
+  const plantSeed = useCallback((plotId) => {
+    gameEngine.plantSeed(plotId);
+  }, [gameEngine]);
 
-  const buySeed = (seedType) => {
-    const price = marketPrices[seedType] || CROPS[seedType].price;
-    if (money >= price) {
-      setMoney(prev => prev - price);
-      setSelectedSeed(seedType);
-      setShowShop(false);
-      addNotification(`購買了 ${CROPS[seedType].name} 種子！`);
-    } else {
-      addNotification('金錢不足！');
-    }
-  };
+  const harvestCrop = useCallback((plotId) => {
+    gameEngine.harvestCrop(plotId);
+  }, [gameEngine]);
 
-  const plantSeed = (plotId) => {
-    if (!selectedSeed) return;
-    
-    const energyCost = Math.max(1, 10 - TOOLS[tools].energyReduction - (buildings.well ? 5 : 0));
-    if (energy < energyCost) {
-      addNotification('體力不足！');
-      return;
-    }
-    
-    setFarm(prev => prev.map(plot => 
-      plot.id === plotId && !plot.crop
-        ? { ...plot, crop: selectedSeed, plantTime: Date.now(), watered: false, ready: false, pest: false }
-        : plot
-    ));
-    
-    setEnergy(prev => Math.max(0, prev - energyCost));
-    setExperience(prev => prev + 5);
-    setSelectedSeed(null);
-    addNotification(`種植了 ${CROPS[selectedSeed].name}！`);
-  };
+  const waterPlot = useCallback((plotId) => {
+    gameEngine.waterPlot(plotId);
+  }, [gameEngine]);
 
-  const harvestCrop = (plotId) => {
-    const plot = farm.find(p => p.id === plotId);
-    if (!plot || !plot.ready) return;
+  const buyAnimal = useCallback((animalType) => {
+    gameEngine.buyAnimal(animalType);
+  }, [gameEngine]);
 
-    const crop = plot.crop;
-    const basePrice = marketPrices[crop] || CROPS[crop].sellPrice;
-    
-    let bonus = 1;
-    if (plot.watered) bonus *= 1.2;
-    if (plot.greenhouse) bonus *= 1.5;
-    if (buildings.silo) bonus *= 1.1;
-    
-    const sellPrice = Math.floor(basePrice * bonus);
-    
-    setMoney(prev => prev + sellPrice);
-    setInventory(prev => ({ ...prev, [crop]: prev[crop] + 1 }));
-    setExperience(prev => prev + 10);
-    
-    setFarm(prev => prev.map(plot => 
-      plot.id === plotId 
-        ? { ...plot, crop: null, plantTime: null, watered: false, ready: false, pest: false }
-        : plot
-    ));
+  const buyBuilding = useCallback((buildingType) => {
+    gameEngine.buyBuilding(buildingType);
+  }, [gameEngine]);
 
-    addNotification(`收成了 ${CROPS[crop].emoji}！獲得 $${sellPrice}`);
-  };
+  const buyTool = useCallback((toolType) => {
+    gameEngine.buyTool(toolType);
+  }, [gameEngine]);
 
-  const waterPlot = (plotId) => {
-    const energyCost = buildings.well ? 2 : 5;
-    if (energy < energyCost) return;
-    
-    setFarm(prev => prev.map(plot => 
-      plot.id === plotId && plot.crop && !plot.watered
-        ? { ...plot, watered: true }
-        : plot
-    ));
-    
-    setEnergy(prev => Math.max(0, prev - energyCost));
-    addNotification('澆水完成！');
-  };
-
-  const buyAnimal = (animalType) => {
-    if (money >= ANIMALS[animalType].price) {
-      setMoney(prev => prev - ANIMALS[animalType].price);
-      setAnimals(prev => [...prev, {
-        id: Date.now(),
-        type: animalType,
-        happiness: ANIMALS[animalType].happiness,
-        name: ANIMALS[animalType].name + (prev.filter(a => a.type === animalType).length + 1)
-      }]);
-      setShowAnimalShop(false);
-      addNotification(`購買了 ${ANIMALS[animalType].emoji} ${ANIMALS[animalType].name}！`);
-    } else {
-      addNotification('金錢不足！');
-    }
-  };
-
-  const buyBuilding = (buildingType) => {
-    if (money >= BUILDINGS[buildingType].price && !buildings[buildingType]) {
-      setMoney(prev => prev - BUILDINGS[buildingType].price);
-      setBuildings(prev => ({ ...prev, [buildingType]: true }));
-      
-      if (buildingType === 'greenhouse') {
-        setFarm(prev => prev.map((plot, index) => 
-          index < 5 ? { ...plot, greenhouse: true } : plot
-        ));
-      }
-      
-      setShowBuildingShop(false);
-      addNotification(`建造了 ${BUILDINGS[buildingType].emoji} ${BUILDINGS[buildingType].name}！`);
-    } else if (buildings[buildingType]) {
-      addNotification('已經擁有此建築！');
-    } else {
-      addNotification('金錢不足！');
-    }
-  };
-
-  const buyTool = (toolType) => {
-    if (money >= TOOLS[toolType].price && tools !== toolType) {
-      setMoney(prev => prev - TOOLS[toolType].price);
-      setTools(toolType);
-      setShowToolShop(false);
-      addNotification(`升級工具：${TOOLS[toolType].name}！`);
-    }
-  };
-
-  const feedAnimal = (animalId) => {
-    const animal = animals.find(a => a.id === animalId);
-    if (!animal || money < ANIMALS[animal.type].foodCost) return;
-
-    setMoney(prev => prev - ANIMALS[animal.type].foodCost);
-    setAnimals(prev => prev.map(a => 
-      a.id === animalId 
-        ? { ...a, happiness: Math.min(100, a.happiness + 25) }
-        : a
-    ));
-    addNotification(`餵食了 ${animal.name}！快樂度 +25`);
-  };
+  const feedAnimal = useCallback((animalId) => {
+    gameEngine.feedAnimal(animalId);
+  }, [gameEngine]);
 
   const interactNPC = (npc) => {
     setCurrentNPC(npc);
@@ -626,16 +391,6 @@ const FarmGame = () => {
   const getTimeIcon = () => {
     if (time >= 6 && time < 18) return <Sun className="w-5 h-5 text-yellow-400" />;
     return <Moon className="w-5 h-5 text-blue-300" />;
-  };
-
-  const getWeatherIcon = (weatherType = weather) => {
-    switch (weatherType) {
-      case 'rainy': return '🌧️';
-      case 'cloudy': return '☁️';
-      case 'storm': return '⛈️';
-      case 'snow': return '❄️';
-      default: return '☀️';
-    }
   };
 
   const isNight = time < 6 || time >= 18;
@@ -706,7 +461,7 @@ const FarmGame = () => {
             {getTimeIcon()}
             <span>{time}:00</span>
           </div>
-          <span>{getWeatherIcon()}</span>
+          <span>{GameFormatter.weatherIcon(weather)}</span>
           <span>第{day}天</span>
         </div>
       </div>
@@ -718,7 +473,7 @@ const FarmGame = () => {
           <div className="lg:col-span-3 bg-white bg-opacity-90 rounded-lg p-4 shadow-lg">
             <h2 className="text-xl font-bold mb-4 flex items-center">
               <Home className="mr-2" />
-              我的農場 - {getSeasonName(season)} {getWeatherName(weather)}
+              我的農場 - {GameFormatter.seasonName(season)} {GameFormatter.weatherName(weather)}
             </h2>
             
             {/* NPC區域 */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target } from 'lucide-react';
+import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed } from 'lucide-react';
 import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS } from './game/data/GameCatalog';
 import { GameFormatter } from './game/utils/GameFormatter';
 import { GameEngine } from './game/engine/GameEngine';
@@ -55,8 +55,11 @@ const FarmGame = () => {
   const [notifications, setNotifications] = useState([]);
 
   const notificationCenter = useMemo(() => new NotificationCenter(setNotifications), []);
-  const addNotification = useCallback((message) => {
-    notificationCenter.push(message);
+  const addNotification = useCallback((message, options) => {
+    notificationCenter.push(message, options);
+  }, [notificationCenter]);
+  const dismissNotification = useCallback((id) => {
+    notificationCenter.dismiss(id);
   }, [notificationCenter]);
   
   // 新功能狀態
@@ -184,20 +187,26 @@ const FarmGame = () => {
   // AI顧問系統
   useEffect(() => {
     const generateAdvice = () => {
+      const safeAnimals = Array.isArray(animals) ? animals : [];
+      const safeInventory = inventory || {};
+
       const advices = [
         weather === 'sunny' ? '☀️ 晴天適合種植番茄和草莓！' : '',
         weather === 'rainy' ? '🌧️ 雨天作物會自動澆水，適合種植小麥！' : '',
         energy < 30 ? '⚡ 體力不足，建議休息或升級工具！' : '',
         money > 2000 ? '💰 資金充足，考慮建造新建築！' : '',
-        animals.some(a => a.happiness < 30) ? '🐾 有動物不開心，記得餵食！' : '',
-        Object.values(inventory).some(count => count > 10) ? '📦 庫存充足，可以考慮出售！' : ''
-      ].filter(advice => advice);
-      
+        safeAnimals.some(a => (a.happiness ?? 50) < 40) ? '🐾 有動物心情低落，餵食或陪伴牠們吧！' : '',
+        safeAnimals.some(a => (a.hunger ?? 60) < 35) ? '🍽️ 有動物快餓扁了，趕快餵牠們！' : '',
+        Object.values(safeInventory).some(count => count > 10) ? '📦 庫存充足，可以考慮出售！' : '',
+      ].filter(Boolean);
+
       if (advices.length > 0) {
         setAiAdvice(advices[Math.floor(Math.random() * advices.length)]);
+      } else {
+        setAiAdvice('🌱 保持平衡發展，慢慢擴張農場！');
       }
     };
-    
+
     const timer = setInterval(generateAdvice, 60000);
     generateAdvice();
     return () => clearInterval(timer);
@@ -250,7 +259,7 @@ const FarmGame = () => {
         if (unlocked) {
           setCompletedAchievements(prev => new Set([...prev, achievement.id]));
           setMoney(prev => prev + achievement.reward);
-          addNotification(`🏆 達成成就：${achievement.name}！獲得 $${achievement.reward}`);
+          addNotification(`🏆 達成成就：${achievement.name}！獲得 $${achievement.reward}`, { type: 'success' });
         }
       }
     });
@@ -268,29 +277,69 @@ const FarmGame = () => {
               const currentSeasonIndex = SEASONS.indexOf(season);
               const nextSeason = SEASONS[(currentSeasonIndex + 1) % SEASONS.length];
               setSeason(nextSeason);
-              addNotification(`🌸 季節變為 ${GameFormatter.seasonName(nextSeason)}！`);
+              addNotification(`🌸 季節變為 ${GameFormatter.seasonName(nextSeason)}！`, { type: 'info' });
             }
             return newDay;
           });
           
           setEnergy(100);
-          
-          // 動物每日收入
-          setAnimals(prev => prev.map(animal => {
-            const building = buildings[ANIMALS[animal.type].shelter];
-            const boost = building ? BUILDINGS[ANIMALS[animal.type].shelter].boost : 1;
-            const income = Math.floor(ANIMALS[animal.type].income * boost * (animal.happiness / 100));
-            
-            if (animal.happiness > 20) {
-              setMoney(prevMoney => prevMoney + income);
+
+          // 動物每日狀態與收入結算
+          setAnimals(prevAnimals => {
+            if (!Array.isArray(prevAnimals) || prevAnimals.length === 0) {
+              return prevAnimals;
             }
-            
-            return {
-              ...animal,
-              happiness: Math.max(0, animal.happiness - 15)
-            };
-          }));
-          
+
+            let totalIncome = 0;
+            const hungryNames = [];
+
+            const updatedAnimals = prevAnimals.map(animal => {
+              const animalData = ANIMALS[animal.type];
+              const shelterKey = animalData.shelter;
+              const hasShelter = buildings?.[shelterKey];
+              const boost = hasShelter ? BUILDINGS[shelterKey].boost : 1;
+
+              const previousHunger = animal.hunger ?? 60;
+              const hunger = Math.max(0, previousHunger - 30);
+
+              let happiness = Math.max(0, (animal.happiness ?? animalData.happiness) - 10);
+              let canProduce = happiness > 20 && hunger > 30;
+
+              if (hunger <= 10) {
+                hungryNames.push(`${animal.name}（急需餵食）`);
+                happiness = Math.max(0, happiness - 25);
+                canProduce = false;
+              } else if (hunger <= 30) {
+                hungryNames.push(animal.name);
+                happiness = Math.max(0, happiness - 10);
+                canProduce = happiness > 25;
+              }
+
+              const income = canProduce
+                ? Math.floor(animalData.income * boost * (happiness / 100))
+                : 0;
+              totalIncome += income;
+
+              return {
+                ...animal,
+                happiness,
+                hunger,
+              };
+            });
+
+            if (totalIncome > 0) {
+              setMoney(prevMoney => prevMoney + totalIncome);
+              addNotification(`🐾 動物們帶來了 $${totalIncome} 的收入！`, { type: 'success' });
+            }
+
+            if (hungryNames.length > 0) {
+              const names = Array.from(new Set(hungryNames)).join('、');
+              addNotification(`🍽️ ${names} 肚子餓了，記得餵食！`, { type: 'warning' });
+            }
+
+            return updatedAnimals;
+          });
+
           return 6;
         }
         return newTime;
@@ -307,7 +356,7 @@ const FarmGame = () => {
         if (prev <= 0) {
           const newWeather = WEATHER_TYPES[Math.floor(Math.random() * WEATHER_TYPES.length)];
           setWeather(newWeather);
-          addNotification(`天氣變為 ${GameFormatter.weatherName(newWeather)} ${GameFormatter.weatherIcon(newWeather)}`);
+          addNotification(`天氣變為 ${GameFormatter.weatherName(newWeather)} ${GameFormatter.weatherIcon(newWeather)}`, { type: 'info' });
           return Math.floor(Math.random() * 8) + 3;
         }
         return prev - 1;
@@ -331,7 +380,7 @@ const FarmGame = () => {
           const adjustedGrowTime = (cropData.growTime * 60000) / (weatherMultiplier * toolMultiplier);
           
           if (now - plot.plantTime >= adjustedGrowTime && !plot.ready) {
-            addNotification(`${cropData.emoji} ${cropData.name} 成熟了！`);
+            addNotification(`${cropData.emoji} ${cropData.name} 成熟了！`, { type: 'success' });
             return { ...plot, ready: true };
           }
         }
@@ -347,7 +396,7 @@ const FarmGame = () => {
     if (experience >= level * 100) {
       setLevel(prev => prev + 1);
       setExperience(prev => prev - (level * 100));
-      addNotification(`🎉 升級到等級 ${level + 1}！`);
+      addNotification(`🎉 升級到等級 ${level + 1}！`, { type: 'success' });
     }
   }, [experience, level, addNotification]);
 
@@ -403,12 +452,32 @@ const FarmGame = () => {
     }`}>
       {/* 通知系統 */}
       <div className="fixed top-4 right-4 z-50 space-y-2 max-w-xs">
-        {notifications.map(notification => (
-          <div key={notification.id} 
-               className="bg-green-500 text-white px-3 py-2 rounded-lg shadow-lg animate-bounce text-sm">
-            {notification.message}
-          </div>
-        ))}
+        {notifications.map(notification => {
+          const styleByType = {
+            success: 'bg-green-500/95 border-green-300',
+            info: 'bg-blue-500/95 border-blue-300',
+            warning: 'bg-yellow-500/95 border-yellow-300',
+            error: 'bg-red-500/95 border-red-300',
+          };
+          const tone = styleByType[notification.type] || styleByType.info;
+          const textClass = notification.type === 'warning' ? 'text-gray-900' : 'text-white';
+          const closeClass = notification.type === 'warning'
+            ? 'text-gray-500 hover:text-gray-700'
+            : 'text-white/80 hover:text-white';
+          return (
+            <div key={notification.id}
+                 className={`px-4 py-3 rounded-lg shadow-lg border flex items-start justify-between gap-2 text-sm transition-all duration-500 backdrop-blur ${tone} ${textClass}`}>
+              <span className="leading-snug">{notification.message}</span>
+              <button
+                onClick={() => dismissNotification(notification.id)}
+                className={closeClass}
+                aria-label="關閉通知"
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
       </div>
 
       {/* 頂部狀態欄 */}
@@ -559,34 +628,57 @@ const FarmGame = () => {
                 <h3 className="text-lg font-bold mb-3">我的動物們</h3>
                 <div className="grid grid-cols-4 gap-4">
                   {animals.map((animal) => {
-                    const hasBuilding = buildings[ANIMALS[animal.type].shelter];
+                    const animalData = ANIMALS[animal.type];
+                    const hasBuilding = buildings[animalData.shelter];
+                    const hunger = animal.hunger ?? 50;
+                    const isHungry = hunger <= 30;
                     return (
-                      <div key={animal.id} 
-                           className={`rounded-lg p-3 cursor-pointer transition-colors relative ${
+                      <div key={animal.id}
+                           className={`rounded-lg p-3 transition-colors relative ${
                              hasBuilding ? 'bg-green-100 hover:bg-green-200' : 'bg-blue-100 hover:bg-blue-200'
-                           }`}
-                           onClick={() => feedAnimal(animal.id)}>
+                           }`}>
                         {hasBuilding && (
                           <div className="absolute top-1 right-1 text-xs">
-                            {BUILDINGS[ANIMALS[animal.type].shelter].emoji}
+                            {BUILDINGS[animalData.shelter].emoji}
                           </div>
                         )}
-                        <div className="text-center">
-                          <div className="text-3xl mb-2 animate-bounce">
-                            {ANIMALS[animal.type].emoji}
+                        <div className="text-center space-y-2">
+                          <div className="text-3xl animate-bounce">
+                            {animalData.emoji}
                           </div>
                           <div className="text-sm font-semibold">{animal.name}</div>
-                          <div className="flex items-center justify-center mt-1">
-                            <Heart className="w-3 h-3 text-red-400 mr-1" />
-                            <span className="text-xs">{animal.happiness}/100</span>
+                          <div className="space-y-1 text-xs">
+                            <div className="flex items-center justify-center gap-1">
+                              <Heart className="w-3 h-3 text-red-400" />
+                              <span>{Math.round(animal.happiness ?? animalData.happiness)} / 100</span>
+                            </div>
+                            <div className="bg-gray-200 rounded-full h-1">
+                              <div className="bg-red-400 h-1 rounded-full transition-all duration-300"
+                                   style={{ width: `${Math.max(0, Math.min(100, animal.happiness ?? animalData.happiness))}%` }}></div>
+                            </div>
+                            <div className="flex items-center justify-center gap-1 mt-2">
+                              <UtensilsCrossed className={`w-3 h-3 ${isHungry ? 'text-orange-500' : 'text-amber-400'}`} />
+                              <span>{Math.round(hunger)}%</span>
+                            </div>
+                            <div className="bg-gray-200 rounded-full h-1">
+                              <div className={`h-1 rounded-full transition-all duration-300 ${isHungry ? 'bg-orange-400' : 'bg-yellow-400'}`}
+                                   style={{ width: `${Math.max(0, Math.min(100, hunger))}%` }}></div>
+                            </div>
                           </div>
-                          <div className="bg-gray-200 rounded-full h-1 mt-1">
-                            <div className="bg-red-400 h-1 rounded-full transition-all duration-300"
-                                 style={{width: `${animal.happiness}%`}}></div>
+                          <div className="text-xs text-green-600">
+                            日收入: ${Math.floor(animalData.income * (hasBuilding ? BUILDINGS[animalData.shelter].boost : 1))}
                           </div>
-                          <div className="text-xs text-green-600 mt-1">
-                            日收入: ${Math.floor(ANIMALS[animal.type].income * (hasBuilding ? BUILDINGS[ANIMALS[animal.type].shelter].boost : 1))}
-                          </div>
+                          <button
+                            onClick={() => feedAnimal(animal.id)}
+                            className={`w-full text-xs font-semibold py-1 rounded transition-colors ${
+                              isHungry ? 'bg-orange-500 hover:bg-orange-600 text-white' : 'bg-yellow-300 hover:bg-yellow-400 text-amber-800'
+                            }`}
+                          >
+                            餵食 (-${animalData.foodCost})
+                          </button>
+                          {isHungry && (
+                            <div className="text-xs text-orange-600">肚子餓扁了，快餵我！</div>
+                          )}
                         </div>
                       </div>
                     );
@@ -1164,7 +1256,7 @@ const FarmGame = () => {
             <div className="flex space-x-2 mt-4">
               <button onClick={() => {
                 navigator.clipboard?.writeText(saveData);
-                addNotification('存檔數據已複製到剪貼板！');
+                addNotification('存檔數據已複製到剪貼板！', { type: 'info' });
               }}
                       className="flex-1 bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded transition-colors">
                 📋 複製到剪貼板

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -1,0 +1,170 @@
+class BaseEntity {
+  static nextId = 1;
+
+  constructor(key) {
+    this.id = BaseEntity.nextId++;
+    this.key = key;
+  }
+}
+
+class Crop extends BaseEntity {
+  constructor(key, { name, price, growTime, sellPrice, emoji, weatherBonus }) {
+    super(key);
+    this.name = name;
+    this.price = price;
+    this.growTime = growTime;
+    this.sellPrice = sellPrice;
+    this.emoji = emoji;
+    this.weatherBonus = weatherBonus;
+  }
+}
+
+class Animal extends BaseEntity {
+  constructor(key, { name, price, happiness, emoji, foodCost, income, shelter }) {
+    super(key);
+    this.name = name;
+    this.price = price;
+    this.happiness = happiness;
+    this.emoji = emoji;
+    this.foodCost = foodCost;
+    this.income = income;
+    this.shelter = shelter;
+  }
+}
+
+class Building extends BaseEntity {
+  constructor(key, { name, price, emoji, description, boost }) {
+    super(key);
+    this.name = name;
+    this.price = price;
+    this.emoji = emoji;
+    this.description = description;
+    this.boost = boost;
+  }
+}
+
+class Tool extends BaseEntity {
+  constructor(key, { name, energyReduction, speedBoost, price }) {
+    super(key);
+    this.name = name;
+    this.energyReduction = energyReduction;
+    this.speedBoost = speedBoost;
+    this.price = price;
+  }
+}
+
+class Achievement {
+  constructor({ id, name, description, reward, icon }) {
+    this.id = id;
+    this.name = name;
+    this.description = description;
+    this.reward = reward;
+    this.icon = icon;
+  }
+}
+
+class NPC {
+  constructor({ name, emoji, dialogue, quests }) {
+    this.name = name;
+    this.emoji = emoji;
+    this.dialogue = dialogue;
+    this.quests = quests;
+  }
+}
+
+class GameCatalog {
+  constructor() {
+    this.crops = {
+      carrot: new Crop('carrot', { name: '胡蘿蔔', price: 10, growTime: 5, sellPrice: 25, emoji: '🥕', weatherBonus: { sunny: 1.2, rainy: 1.0, snow: 0.8 } }),
+      corn: new Crop('corn', { name: '玉米', price: 20, growTime: 8, sellPrice: 50, emoji: '🌽', weatherBonus: { sunny: 1.3, rainy: 1.1, snow: 0.6 } }),
+      tomato: new Crop('tomato', { name: '番茄', price: 15, growTime: 6, sellPrice: 35, emoji: '🍅', weatherBonus: { sunny: 1.4, rainy: 0.9, snow: 0.5 } }),
+      wheat: new Crop('wheat', { name: '小麥', price: 8, growTime: 4, sellPrice: 20, emoji: '🌾', weatherBonus: { sunny: 1.1, rainy: 1.2, snow: 0.9 } }),
+      potato: new Crop('potato', { name: '馬鈴薯', price: 12, growTime: 7, sellPrice: 30, emoji: '🥔', weatherBonus: { sunny: 1.0, rainy: 1.3, snow: 1.1 } }),
+      strawberry: new Crop('strawberry', { name: '草莓', price: 25, growTime: 10, sellPrice: 60, emoji: '🍓', weatherBonus: { sunny: 1.2, rainy: 0.8, snow: 0.4 } }),
+    };
+
+    this.animals = {
+      dog: new Animal('dog', { name: '狗狗', price: 200, happiness: 50, emoji: '🐕', foodCost: 5, income: 8, shelter: 'dogHouse' }),
+      cat: new Animal('cat', { name: '貓咪', price: 150, happiness: 60, emoji: '🐱', foodCost: 3, income: 5, shelter: 'catHouse' }),
+      chicken: new Animal('chicken', { name: '雞', price: 100, happiness: 40, emoji: '🐔', foodCost: 2, income: 12, shelter: 'chickenCoop' }),
+      cow: new Animal('cow', { name: '牛', price: 500, happiness: 30, emoji: '🐄', foodCost: 10, income: 25, shelter: 'barn' }),
+      pig: new Animal('pig', { name: '豬', price: 300, happiness: 45, emoji: '🐷', foodCost: 8, income: 18, shelter: 'pigPen' }),
+      sheep: new Animal('sheep', { name: '羊', price: 250, happiness: 40, emoji: '🐑', foodCost: 6, income: 15, shelter: 'barn' }),
+      duck: new Animal('duck', { name: '鴨子', price: 120, happiness: 55, emoji: '🦆', foodCost: 3, income: 10, shelter: 'pond' }),
+      rabbit: new Animal('rabbit', { name: '兔子', price: 80, happiness: 70, emoji: '🐰', foodCost: 2, income: 6, shelter: 'rabbitHutch' }),
+    };
+
+    this.buildings = {
+      barn: new Building('barn', { name: '穀倉', price: 1000, emoji: '🏚️', description: '容納牛羊，提升產量', boost: 1.2 }),
+      chickenCoop: new Building('chickenCoop', { name: '雞舍', price: 500, emoji: '🏠', description: '專門養雞，提升產蛋率', boost: 1.3 }),
+      dogHouse: new Building('dogHouse', { name: '狗屋', price: 300, emoji: '🏘️', description: '狗狗的溫馨小窩', boost: 1.1 }),
+      catHouse: new Building('catHouse', { name: '貓屋', price: 250, emoji: '🏡', description: '貓咪的舒適居所', boost: 1.1 }),
+      pigPen: new Building('pigPen', { name: '豬圈', price: 400, emoji: '🏗️', description: '豬豬的泥土樂園', boost: 1.2 }),
+      pond: new Building('pond', { name: '池塘', price: 600, emoji: '🌊', description: '水鳥的天堂', boost: 1.3 }),
+      rabbitHutch: new Building('rabbitHutch', { name: '兔籠', price: 200, emoji: '📦', description: '兔子的安全小屋', boost: 1.2 }),
+      greenhouse: new Building('greenhouse', { name: '溫室', price: 2000, emoji: '🏢', description: '不受天氣影響的種植空間', boost: 1.5 }),
+      silo: new Building('silo', { name: '筒倉', price: 800, emoji: '🗼', description: '儲存更多作物', boost: 1.0 }),
+      windmill: new Building('windmill', { name: '風車', price: 1500, emoji: '🌪️', description: '產生額外收入', boost: 1.0 }),
+      well: new Building('well', { name: '水井', price: 400, emoji: '🕳️', description: '無限澆水，節省體力', boost: 1.0 }),
+    };
+
+    this.tools = {
+      basic: new Tool('basic', { name: '基本工具', energyReduction: 0, speedBoost: 1, price: 0 }),
+      iron: new Tool('iron', { name: '鐵製工具', energyReduction: 2, speedBoost: 1.2, price: 500 }),
+      steel: new Tool('steel', { name: '鋼製工具', energyReduction: 4, speedBoost: 1.5, price: 1200 }),
+      magic: new Tool('magic', { name: '魔法工具', energyReduction: 6, speedBoost: 2, price: 3000 }),
+    };
+
+    this.achievements = [
+      new Achievement({ id: 'firstPlant', name: '初次種植', description: '種下第一株作物', reward: 100, icon: '🌱' }),
+      new Achievement({ id: 'richFarmer', name: '富豪農夫', description: '擁有10000金幣', reward: 500, icon: '💰' }),
+      new Achievement({ id: 'animalLover', name: '動物愛好者', description: '擁有10隻動物', reward: 300, icon: '🐾' }),
+      new Achievement({ id: 'builder', name: '建築大師', description: '建造5個建築', reward: 800, icon: '🏗️' }),
+      new Achievement({ id: 'levelUp', name: '經驗老手', description: '達到等級10', reward: 1000, icon: '⭐' }),
+      new Achievement({ id: 'weatherMaster', name: '天氣專家', description: '在所有天氣下收成作物', reward: 600, icon: '🌦️' }),
+    ];
+
+    this.npcs = [
+      new NPC({
+        name: '農夫老張',
+        emoji: '👨‍🌾',
+        dialogue: ['今天天氣真好呢！', '記得給作物澆水哦！', '我這裡有些好種子...'],
+        quests: [{ type: 'plant', target: 'carrot', count: 5, reward: 200 }],
+      }),
+      new NPC({
+        name: '商人小李',
+        emoji: '👨‍💼',
+        dialogue: ['生意興隆！', '需要什麼嗎？', '我有特價商品！'],
+        quests: [{ type: 'sell', target: 'tomato', count: 10, reward: 300 }],
+      }),
+    ];
+  }
+
+  getCrop(key) {
+    return this.crops[key];
+  }
+
+  getAnimal(key) {
+    return this.animals[key];
+  }
+
+  getBuilding(key) {
+    return this.buildings[key];
+  }
+
+  getTool(key) {
+    return this.tools[key];
+  }
+}
+
+export const WEATHER_TYPES = ['sunny', 'rainy', 'cloudy', 'storm', 'snow'];
+export const SEASONS = ['spring', 'summer', 'autumn', 'winter'];
+
+export const catalog = new GameCatalog();
+export const CROPS = catalog.crops;
+export const ANIMALS = catalog.animals;
+export const BUILDINGS = catalog.buildings;
+export const TOOLS = catalog.tools;
+export const ACHIEVEMENTS = catalog.achievements;
+export const NPCS = catalog.npcs;
+

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -1,0 +1,176 @@
+import { CROPS, ANIMALS, BUILDINGS, TOOLS } from '../data/GameCatalog';
+
+export class GameEngine {
+  constructor({ stateRef, setters, notifier }) {
+    this.stateRef = stateRef;
+    this.setters = setters;
+    this.notifier = notifier;
+  }
+
+  get state() {
+    return this.stateRef.current;
+  }
+
+  notify(message) {
+    if (this.notifier) {
+      this.notifier(message);
+    }
+  }
+
+  buySeed(seedType) {
+    const { money, marketPrices } = this.state;
+    const price = (marketPrices && marketPrices[seedType]) || CROPS[seedType].price;
+
+    if (money >= price) {
+      this.setters.setMoney(prev => prev - price);
+      this.setters.setSelectedSeed(seedType);
+      this.setters.setShowShop(false);
+      this.notify(`購買了 ${CROPS[seedType].name} 種子！`);
+    } else {
+      this.notify('金錢不足！');
+    }
+  }
+
+  plantSeed(plotId) {
+    const { selectedSeed, tools, buildings, energy } = this.state;
+    if (!selectedSeed) return;
+
+    const energyCost = Math.max(1, 10 - TOOLS[tools].energyReduction - (buildings?.well ? 5 : 0));
+    if (energy < energyCost) {
+      this.notify('體力不足！');
+      return;
+    }
+
+    this.setters.setFarm(prev => prev.map(plot =>
+      plot.id === plotId && !plot.crop
+        ? { ...plot, crop: selectedSeed, plantTime: Date.now(), watered: false, ready: false, pest: false }
+        : plot
+    ));
+
+    this.setters.setEnergy(prev => Math.max(0, prev - energyCost));
+    this.setters.setExperience(prev => prev + 5);
+    this.setters.setSelectedSeed(null);
+    this.notify(`種植了 ${CROPS[selectedSeed].name}！`);
+  }
+
+  harvestCrop(plotId) {
+    const { farm, marketPrices, buildings } = this.state;
+    const plot = farm.find(p => p.id === plotId);
+    if (!plot || !plot.ready) return;
+
+    const crop = plot.crop;
+    const basePrice = (marketPrices && marketPrices[crop]) || CROPS[crop].sellPrice;
+
+    let bonus = 1;
+    if (plot.watered) bonus *= 1.2;
+    if (plot.greenhouse) bonus *= 1.5;
+    if (buildings?.silo) bonus *= 1.1;
+
+    const sellPrice = Math.floor(basePrice * bonus);
+
+    this.setters.setMoney(prev => prev + sellPrice);
+    this.setters.setInventory(prev => ({ ...prev, [crop]: prev[crop] + 1 }));
+    this.setters.setExperience(prev => prev + 10);
+    this.setters.setFarm(prev => prev.map(p =>
+      p.id === plotId
+        ? { ...p, crop: null, plantTime: null, watered: false, ready: false, pest: false }
+        : p
+    ));
+
+    this.notify(`收成了 ${CROPS[crop].emoji}！獲得 $${sellPrice}`);
+  }
+
+  waterPlot(plotId) {
+    const { energy, buildings } = this.state;
+    const energyCost = buildings?.well ? 2 : 5;
+    if (energy < energyCost) return;
+
+    this.setters.setFarm(prev => prev.map(plot =>
+      plot.id === plotId && plot.crop && !plot.watered
+        ? { ...plot, watered: true }
+        : plot
+    ));
+
+    this.setters.setEnergy(prev => Math.max(0, prev - energyCost));
+    this.notify('澆水完成！');
+  }
+
+  buyAnimal(animalType) {
+    const { money } = this.state;
+    const animal = ANIMALS[animalType];
+
+    if (money >= animal.price) {
+      this.setters.setMoney(prev => prev - animal.price);
+      this.setters.setAnimals(prev => [...prev, {
+        id: Date.now(),
+        type: animalType,
+        happiness: animal.happiness,
+        name: `${animal.name}${prev.filter(a => a.type === animalType).length + 1}`,
+      }]);
+      this.setters.setShowAnimalShop(false);
+      this.notify(`購買了 ${animal.emoji} ${animal.name}！`);
+    } else {
+      this.notify('金錢不足！');
+    }
+  }
+
+  buyBuilding(buildingType) {
+    const { money, buildings } = this.state;
+    const building = BUILDINGS[buildingType];
+
+    if (buildings?.[buildingType]) {
+      this.notify('已經擁有此建築！');
+      return;
+    }
+
+    if (money >= building.price) {
+      this.setters.setMoney(prev => prev - building.price);
+      this.setters.setBuildings(prev => ({ ...prev, [buildingType]: true }));
+
+      if (buildingType === 'greenhouse') {
+        this.setters.setFarm(prev => prev.map((plot, index) =>
+          index < 5 ? { ...plot, greenhouse: true } : plot
+        ));
+      }
+
+      this.setters.setShowBuildingShop(false);
+      this.notify(`建造了 ${building.emoji} ${building.name}！`);
+    } else {
+      this.notify('金錢不足！');
+    }
+  }
+
+  buyTool(toolType) {
+    const { money, tools } = this.state;
+    const tool = TOOLS[toolType];
+
+    if (tools === toolType) return;
+
+    if (money >= tool.price) {
+      this.setters.setMoney(prev => prev - tool.price);
+      this.setters.setTools(toolType);
+      this.setters.setShowToolShop(false);
+      this.notify(`升級工具：${tool.name}！`);
+    } else {
+      this.notify('金錢不足！');
+    }
+  }
+
+  feedAnimal(animalId) {
+    const { animals, money } = this.state;
+    const animal = animals.find(a => a.id === animalId);
+    if (!animal) return;
+
+    const cost = ANIMALS[animal.type].foodCost;
+    if (money < cost) return;
+
+    this.setters.setMoney(prev => prev - cost);
+    this.setters.setAnimals(prev => prev.map(a =>
+      a.id === animalId
+        ? { ...a, happiness: Math.min(100, a.happiness + 25) }
+        : a
+    ));
+    this.notify(`餵食了 ${animal.name}！快樂度 +25`);
+  }
+}
+

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -11,9 +11,9 @@ export class GameEngine {
     return this.stateRef.current;
   }
 
-  notify(message) {
+  notify(message, options) {
     if (this.notifier) {
-      this.notifier(message);
+      this.notifier(message, options);
     }
   }
 
@@ -25,9 +25,9 @@ export class GameEngine {
       this.setters.setMoney(prev => prev - price);
       this.setters.setSelectedSeed(seedType);
       this.setters.setShowShop(false);
-      this.notify(`購買了 ${CROPS[seedType].name} 種子！`);
+      this.notify(`購買了 ${CROPS[seedType].name} 種子！`, { type: 'success' });
     } else {
-      this.notify('金錢不足！');
+      this.notify('金錢不足！', { type: 'error' });
     }
   }
 
@@ -37,7 +37,7 @@ export class GameEngine {
 
     const energyCost = Math.max(1, 10 - TOOLS[tools].energyReduction - (buildings?.well ? 5 : 0));
     if (energy < energyCost) {
-      this.notify('體力不足！');
+      this.notify('體力不足！', { type: 'warning' });
       return;
     }
 
@@ -50,7 +50,7 @@ export class GameEngine {
     this.setters.setEnergy(prev => Math.max(0, prev - energyCost));
     this.setters.setExperience(prev => prev + 5);
     this.setters.setSelectedSeed(null);
-    this.notify(`種植了 ${CROPS[selectedSeed].name}！`);
+    this.notify(`種植了 ${CROPS[selectedSeed].name}！`, { type: 'success' });
   }
 
   harvestCrop(plotId) {
@@ -77,13 +77,16 @@ export class GameEngine {
         : p
     ));
 
-    this.notify(`收成了 ${CROPS[crop].emoji}！獲得 $${sellPrice}`);
+    this.notify(`收成了 ${CROPS[crop].emoji}！獲得 $${sellPrice}`, { type: 'success' });
   }
 
   waterPlot(plotId) {
     const { energy, buildings } = this.state;
     const energyCost = buildings?.well ? 2 : 5;
-    if (energy < energyCost) return;
+    if (energy < energyCost) {
+      this.notify('體力不足，無法澆水！', { type: 'warning' });
+      return;
+    }
 
     this.setters.setFarm(prev => prev.map(plot =>
       plot.id === plotId && plot.crop && !plot.watered
@@ -92,12 +95,19 @@ export class GameEngine {
     ));
 
     this.setters.setEnergy(prev => Math.max(0, prev - energyCost));
-    this.notify('澆水完成！');
+    this.notify('澆水完成！', { type: 'success' });
   }
 
   buyAnimal(animalType) {
     const { money } = this.state;
     const animal = ANIMALS[animalType];
+    const requiredShelter = animal.shelter;
+
+    if (requiredShelter && !this.state.buildings?.[requiredShelter]) {
+      const shelterName = BUILDINGS[requiredShelter].name;
+      this.notify(`需要先建造 ${shelterName} 才能飼養 ${animal.name}！`, { type: 'warning' });
+      return;
+    }
 
     if (money >= animal.price) {
       this.setters.setMoney(prev => prev - animal.price);
@@ -105,12 +115,14 @@ export class GameEngine {
         id: Date.now(),
         type: animalType,
         happiness: animal.happiness,
+        hunger: 70,
+        lastFed: Date.now(),
         name: `${animal.name}${prev.filter(a => a.type === animalType).length + 1}`,
       }]);
       this.setters.setShowAnimalShop(false);
-      this.notify(`購買了 ${animal.emoji} ${animal.name}！`);
+      this.notify(`購買了 ${animal.emoji} ${animal.name}！`, { type: 'success' });
     } else {
-      this.notify('金錢不足！');
+      this.notify('金錢不足！', { type: 'error' });
     }
   }
 
@@ -119,7 +131,7 @@ export class GameEngine {
     const building = BUILDINGS[buildingType];
 
     if (buildings?.[buildingType]) {
-      this.notify('已經擁有此建築！');
+      this.notify('已經擁有此建築！', { type: 'info' });
       return;
     }
 
@@ -134,9 +146,9 @@ export class GameEngine {
       }
 
       this.setters.setShowBuildingShop(false);
-      this.notify(`建造了 ${building.emoji} ${building.name}！`);
+      this.notify(`建造了 ${building.emoji} ${building.name}！`, { type: 'success' });
     } else {
-      this.notify('金錢不足！');
+      this.notify('金錢不足！', { type: 'error' });
     }
   }
 
@@ -150,9 +162,9 @@ export class GameEngine {
       this.setters.setMoney(prev => prev - tool.price);
       this.setters.setTools(toolType);
       this.setters.setShowToolShop(false);
-      this.notify(`升級工具：${tool.name}！`);
+      this.notify(`升級工具：${tool.name}！`, { type: 'success' });
     } else {
-      this.notify('金錢不足！');
+      this.notify('金錢不足！', { type: 'error' });
     }
   }
 
@@ -162,15 +174,29 @@ export class GameEngine {
     if (!animal) return;
 
     const cost = ANIMALS[animal.type].foodCost;
-    if (money < cost) return;
+    if (money < cost) {
+      this.notify('金錢不足，無法購買飼料！', { type: 'error' });
+      return;
+    }
+
+    const currentHunger = animal.hunger ?? 50;
+    if (currentHunger >= 95) {
+      this.notify(`${animal.name} 已經吃得很飽囉！`, { type: 'info' });
+      return;
+    }
 
     this.setters.setMoney(prev => prev - cost);
     this.setters.setAnimals(prev => prev.map(a =>
       a.id === animalId
-        ? { ...a, happiness: Math.min(100, a.happiness + 25) }
+        ? {
+            ...a,
+            happiness: Math.min(100, (a.happiness ?? ANIMALS[a.type].happiness) + 20),
+            hunger: Math.min(100, currentHunger + 40),
+            lastFed: Date.now(),
+          }
         : a
     ));
-    this.notify(`餵食了 ${animal.name}！快樂度 +25`);
+    this.notify(`餵食了 ${animal.name}！`, { type: 'success' });
   }
 }
 

--- a/src/game/engine/NotificationCenter.js
+++ b/src/game/engine/NotificationCenter.js
@@ -1,0 +1,14 @@
+export class NotificationCenter {
+  constructor(setNotifications) {
+    this.setNotifications = setNotifications;
+  }
+
+  push(message) {
+    const id = Date.now() + Math.random();
+    this.setNotifications(prev => [...prev, { id, message }]);
+    setTimeout(() => {
+      this.setNotifications(prev => prev.filter(n => n.id !== id));
+    }, 4000);
+  }
+}
+

--- a/src/game/engine/NotificationCenter.js
+++ b/src/game/engine/NotificationCenter.js
@@ -1,14 +1,35 @@
 export class NotificationCenter {
   constructor(setNotifications) {
     this.setNotifications = setNotifications;
+    this.timeouts = new Map();
   }
 
-  push(message) {
+  push(message, { type = 'info', duration = 4000 } = {}) {
     const id = Date.now() + Math.random();
-    this.setNotifications(prev => [...prev, { id, message }]);
-    setTimeout(() => {
-      this.setNotifications(prev => prev.filter(n => n.id !== id));
-    }, 4000);
+    this.setNotifications(prev => [...prev, { id, message, type }]);
+
+    if (duration > 0) {
+      const timeoutId = setTimeout(() => {
+        this.dismiss(id);
+      }, duration);
+      this.timeouts.set(id, timeoutId);
+    }
+  }
+
+  dismiss(id) {
+    const timeoutId = this.timeouts.get(id);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      this.timeouts.delete(id);
+    }
+
+    this.setNotifications(prev => prev.filter(notification => notification.id !== id));
+  }
+
+  clear() {
+    this.timeouts.forEach(timeoutId => clearTimeout(timeoutId));
+    this.timeouts.clear();
+    this.setNotifications([]);
   }
 }
 

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -1,3 +1,24 @@
+import { ANIMALS, CROPS } from '../data/GameCatalog';
+
+const createDefaultInventory = () => {
+  const inventory = {};
+  Object.keys(CROPS).forEach(key => {
+    inventory[key] = 0;
+  });
+  return inventory;
+};
+
+const createDefaultFarm = () =>
+  Array.from({ length: 25 }, (_, index) => ({
+    id: index,
+    crop: null,
+    plantTime: null,
+    watered: false,
+    fertilized: false,
+    greenhouse: false,
+    pest: false,
+  }));
+
 export class SaveManager {
   constructor({ stateRef, setters, notifier }) {
     this.stateRef = stateRef;
@@ -9,9 +30,9 @@ export class SaveManager {
     return this.stateRef.current;
   }
 
-  notify(message) {
+  notify(message, options) {
     if (this.notifier) {
-      this.notifier(message);
+      this.notifier(message, options);
     }
   }
 
@@ -68,7 +89,7 @@ export class SaveManager {
       [slotName]: snapshot,
     }));
 
-    this.notify(`遊戲已保存到存檔槽 ${slotName.slice(-1)}！`);
+    this.notify(`遊戲已保存到存檔槽 ${slotName.slice(-1)}！`, { type: 'success' });
     this.setters.setShowSaveMenu(false);
   }
 
@@ -82,10 +103,10 @@ export class SaveManager {
 
     try {
       this.applyState(gameState);
-      this.notify(`存檔槽 ${slotName.slice(-1)} 載入成功！`);
+      this.notify(`存檔槽 ${slotName.slice(-1)} 載入成功！`, { type: 'success' });
       this.setters.setShowLoadMenu(false);
     } catch (error) {
-      this.notify('載入存檔失敗！存檔可能已損壞。');
+      this.notify('載入存檔失敗！存檔可能已損壞。', { type: 'error' });
     }
   }
 
@@ -99,11 +120,18 @@ export class SaveManager {
     this.setters.setSeason(gameState.season);
     this.setters.setWeather(gameState.weather);
     this.setters.setWeatherDuration(gameState.weatherDuration || 5);
-    this.setters.setInventory(gameState.inventory);
-    this.setters.setFarm(gameState.farm);
-    this.setters.setAnimals(gameState.animals);
-    this.setters.setBuildings(gameState.buildings);
-    this.setters.setTools(gameState.tools);
+    this.setters.setInventory(gameState.inventory || createDefaultInventory());
+    this.setters.setFarm(Array.isArray(gameState.farm) ? gameState.farm : createDefaultFarm());
+    const sanitizedAnimals = Array.isArray(gameState.animals)
+      ? gameState.animals.map(animal => ({
+          ...animal,
+          happiness: animal.happiness ?? ANIMALS[animal.type]?.happiness ?? 50,
+          hunger: animal.hunger ?? 60,
+        }))
+      : [];
+    this.setters.setAnimals(sanitizedAnimals);
+    this.setters.setBuildings(gameState.buildings || {});
+    this.setters.setTools(gameState.tools || 'basic');
     this.setters.setCompletedAchievements(new Set(gameState.completedAchievements || []));
     this.setters.setDailyStats(gameState.dailyStats || []);
     this.setters.setAutomation(gameState.automation || { autoWater: false, autoHarvest: false });
@@ -114,13 +142,13 @@ export class SaveManager {
     const snapshot = this.createSnapshot();
     const saveString = JSON.stringify(snapshot, null, 2);
     this.setters.setSaveData(saveString);
-    this.notify('存檔數據已生成！請複製保存。');
+    this.notify('存檔數據已生成！請複製保存。', { type: 'info' });
   }
 
   importSave() {
     const { loadData } = this.state;
     if (!loadData || !loadData.trim()) {
-      this.notify('請先輸入存檔數據！');
+      this.notify('請先輸入存檔數據！', { type: 'warning' });
       return;
     }
 
@@ -131,11 +159,11 @@ export class SaveManager {
       }
 
       this.applyState(parsed);
-      this.notify('存檔載入成功！');
+      this.notify('存檔載入成功！', { type: 'success' });
       this.setters.setLoadData('');
       this.setters.setShowLoadMenu(false);
     } catch (error) {
-      this.notify('載入失敗！請檢查存檔數據格式。');
+      this.notify('載入失敗！請檢查存檔數據格式。', { type: 'error' });
     }
   }
 
@@ -144,7 +172,7 @@ export class SaveManager {
       ...prev,
       [slotName]: null,
     }));
-    this.notify(`存檔槽 ${slotName.slice(-1)} 已刪除！`);
+    this.notify(`存檔槽 ${slotName.slice(-1)} 已刪除！`, { type: 'info' });
   }
 
   quickSave() {
@@ -156,7 +184,7 @@ export class SaveManager {
     if (saveSlots?.slot1) {
       this.loadFromSlot('slot1');
     } else {
-      this.notify('快速存檔槽為空！');
+      this.notify('快速存檔槽為空！', { type: 'warning' });
     }
   }
 }

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -1,0 +1,163 @@
+export class SaveManager {
+  constructor({ stateRef, setters, notifier }) {
+    this.stateRef = stateRef;
+    this.setters = setters;
+    this.notifier = notifier;
+  }
+
+  get state() {
+    return this.stateRef.current;
+  }
+
+  notify(message) {
+    if (this.notifier) {
+      this.notifier(message);
+    }
+  }
+
+  createSnapshot() {
+    const {
+      money,
+      energy,
+      level,
+      experience,
+      time,
+      day,
+      season,
+      weather,
+      weatherDuration,
+      inventory,
+      farm,
+      animals,
+      buildings,
+      tools,
+      completedAchievements,
+      dailyStats,
+      automation,
+      marketPrices,
+    } = this.state;
+
+    return {
+      money,
+      energy,
+      level,
+      experience,
+      time,
+      day,
+      season,
+      weather,
+      weatherDuration,
+      inventory,
+      farm,
+      animals,
+      buildings,
+      tools,
+      completedAchievements: Array.from(completedAchievements || []),
+      dailyStats,
+      automation,
+      marketPrices,
+      saveTime: new Date().toISOString(),
+      version: '1.0',
+    };
+  }
+
+  saveToSlot(slotName) {
+    const snapshot = this.createSnapshot();
+    this.setters.setSaveSlots(prev => ({
+      ...prev,
+      [slotName]: snapshot,
+    }));
+
+    this.notify(`遊戲已保存到存檔槽 ${slotName.slice(-1)}！`);
+    this.setters.setShowSaveMenu(false);
+  }
+
+  loadFromSlot(slotName) {
+    const { saveSlots } = this.state;
+    const gameState = saveSlots?.[slotName];
+    if (!gameState) {
+      this.notify('存檔槽為空！');
+      return;
+    }
+
+    try {
+      this.applyState(gameState);
+      this.notify(`存檔槽 ${slotName.slice(-1)} 載入成功！`);
+      this.setters.setShowLoadMenu(false);
+    } catch (error) {
+      this.notify('載入存檔失敗！存檔可能已損壞。');
+    }
+  }
+
+  applyState(gameState) {
+    this.setters.setMoney(gameState.money);
+    this.setters.setEnergy(gameState.energy);
+    this.setters.setLevel(gameState.level);
+    this.setters.setExperience(gameState.experience);
+    this.setters.setTime(gameState.time);
+    this.setters.setDay(gameState.day);
+    this.setters.setSeason(gameState.season);
+    this.setters.setWeather(gameState.weather);
+    this.setters.setWeatherDuration(gameState.weatherDuration || 5);
+    this.setters.setInventory(gameState.inventory);
+    this.setters.setFarm(gameState.farm);
+    this.setters.setAnimals(gameState.animals);
+    this.setters.setBuildings(gameState.buildings);
+    this.setters.setTools(gameState.tools);
+    this.setters.setCompletedAchievements(new Set(gameState.completedAchievements || []));
+    this.setters.setDailyStats(gameState.dailyStats || []);
+    this.setters.setAutomation(gameState.automation || { autoWater: false, autoHarvest: false });
+    this.setters.setMarketPrices(gameState.marketPrices || {});
+  }
+
+  exportSave() {
+    const snapshot = this.createSnapshot();
+    const saveString = JSON.stringify(snapshot, null, 2);
+    this.setters.setSaveData(saveString);
+    this.notify('存檔數據已生成！請複製保存。');
+  }
+
+  importSave() {
+    const { loadData } = this.state;
+    if (!loadData || !loadData.trim()) {
+      this.notify('請先輸入存檔數據！');
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(loadData);
+      if (!parsed.version || parsed.money === undefined) {
+        throw new Error('invalid format');
+      }
+
+      this.applyState(parsed);
+      this.notify('存檔載入成功！');
+      this.setters.setLoadData('');
+      this.setters.setShowLoadMenu(false);
+    } catch (error) {
+      this.notify('載入失敗！請檢查存檔數據格式。');
+    }
+  }
+
+  deleteSaveSlot(slotName) {
+    this.setters.setSaveSlots(prev => ({
+      ...prev,
+      [slotName]: null,
+    }));
+    this.notify(`存檔槽 ${slotName.slice(-1)} 已刪除！`);
+  }
+
+  quickSave() {
+    this.saveToSlot('slot1');
+  }
+
+  quickLoad() {
+    const { saveSlots } = this.state;
+    if (saveSlots?.slot1) {
+      this.loadFromSlot('slot1');
+    } else {
+      this.notify('快速存檔槽為空！');
+    }
+  }
+}
+

--- a/src/game/utils/GameFormatter.js
+++ b/src/game/utils/GameFormatter.js
@@ -1,0 +1,38 @@
+export class GameFormatter {
+  static weatherName(weatherType) {
+    const names = {
+      sunny: '晴天',
+      rainy: '雨天',
+      cloudy: '陰天',
+      storm: '暴風雨',
+      snow: '雪天',
+    };
+    return names[weatherType];
+  }
+
+  static seasonName(seasonType) {
+    const names = {
+      spring: '春天',
+      summer: '夏天',
+      autumn: '秋天',
+      winter: '冬天',
+    };
+    return names[seasonType];
+  }
+
+  static weatherIcon(weatherType) {
+    switch (weatherType) {
+      case 'rainy':
+        return '🌧️';
+      case 'cloudy':
+        return '☁️';
+      case 'storm':
+        return '⛈️';
+      case 'snow':
+        return '❄️';
+      default:
+        return '☀️';
+    }
+  }
+}
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  base: '/FarmGame/'
 })


### PR DESCRIPTION
## Summary
- add an in-game help modal with a player-friendly guide covering key systems
- add a 📖 說明 button to the header to open the modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d249ea88708329974bd0ef414d59ef