### PR TITLE
Add farm supplies and animal health systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview --host",
+    "dev": "node node_modules/vite/bin/vite.js",
+    "build": "node node_modules/vite/bin/vite.js build",
+    "preview": "node node_modules/vite/bin/vite.js preview --host",
 	"deploy": "gh-pages -d dist"
   },
   "dependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed } from 'lucide-react';
-import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS } from './game/data/GameCatalog';
+import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS, FARM_SUPPLIES } from './game/data/GameCatalog';
 import { GameFormatter } from './game/utils/GameFormatter';
 import { GameEngine } from './game/engine/GameEngine';
 import { SaveManager } from './game/engine/SaveManager';
@@ -34,17 +34,25 @@ const FarmGame = () => {
       pest: false
     }))
   );
-  
+
+  const [farmSupplies, setFarmSupplies] = useState({
+    fertilizer: 0,
+    pesticide: 0,
+    medicine: 0,
+  });
+
   const [animals, setAnimals] = useState([]);
   const [buildings, setBuildings] = useState({});
   const [tools, setTools] = useState('basic');
-  
+
   // UI狀態
   const [selectedSeed, setSelectedSeed] = useState(null);
+  const [selectedSupply, setSelectedSupply] = useState(null);
   const [showShop, setShowShop] = useState(false);
   const [showAnimalShop, setShowAnimalShop] = useState(false);
   const [showBuildingShop, setShowBuildingShop] = useState(false);
   const [showToolShop, setShowToolShop] = useState(false);
+  const [showSupplyShop, setShowSupplyShop] = useState(false);
   const [showAchievements, setShowAchievements] = useState(false);
   const [showNPCDialog, setShowNPCDialog] = useState(false);
   const [currentNPC, setCurrentNPC] = useState(null);
@@ -94,6 +102,7 @@ const FarmGame = () => {
     weatherDuration,
     inventory,
     farm,
+    farmSupplies,
     animals,
     buildings,
     tools,
@@ -103,6 +112,7 @@ const FarmGame = () => {
     marketPrices,
     saveSlots,
     selectedSeed,
+    selectedSupply,
     loadData,
   };
 
@@ -123,6 +133,7 @@ const FarmGame = () => {
       setAnimals,
       setBuildings,
       setTools,
+      setFarmSupplies,
       setCompletedAchievements,
       setDailyStats,
       setAutomation,
@@ -132,6 +143,9 @@ const FarmGame = () => {
       setShowLoadMenu,
       setLoadData,
       setSaveData,
+      setSelectedSeed,
+      setSelectedSupply,
+      setShowSupplyShop,
     },
     notifier: addNotification,
   }), [addNotification]);
@@ -141,11 +155,14 @@ const FarmGame = () => {
     setters: {
       setMoney,
       setSelectedSeed,
+      setSelectedSupply,
       setShowShop,
+      setShowSupplyShop,
       setFarm,
       setEnergy,
       setExperience,
       setInventory,
+      setFarmSupplies,
       setAnimals,
       setShowAnimalShop,
       setBuildings,
@@ -189,6 +206,7 @@ const FarmGame = () => {
     const generateAdvice = () => {
       const safeAnimals = Array.isArray(animals) ? animals : [];
       const safeInventory = inventory || {};
+      const safeFarm = Array.isArray(farm) ? farm : [];
 
       const advices = [
         weather === 'sunny' ? '☀️ 晴天適合種植番茄和草莓！' : '',
@@ -197,6 +215,8 @@ const FarmGame = () => {
         money > 2000 ? '💰 資金充足，考慮建造新建築！' : '',
         safeAnimals.some(a => (a.happiness ?? 50) < 40) ? '🐾 有動物心情低落，餵食或陪伴牠們吧！' : '',
         safeAnimals.some(a => (a.hunger ?? 60) < 35) ? '🍽️ 有動物快餓扁了，趕快餵牠們！' : '',
+        safeAnimals.some(a => a.sick) ? '🤒 有動物生病了，使用營養劑能幫助牠們恢復。' : '',
+        safeFarm.some(plot => plot.pest) ? '🐛 有作物遭害蟲啃食，記得噴灑驅蟲劑！' : '',
         Object.values(safeInventory).some(count => count > 10) ? '📦 庫存充足，可以考慮出售！' : '',
       ].filter(Boolean);
 
@@ -210,7 +230,7 @@ const FarmGame = () => {
     const timer = setInterval(generateAdvice, 60000);
     generateAdvice();
     return () => clearInterval(timer);
-  }, [weather, energy, money, animals, inventory]);
+  }, [weather, energy, money, animals, inventory, farm]);
 
   // 動態市場價格
   useEffect(() => {
@@ -292,8 +312,12 @@ const FarmGame = () => {
 
             let totalIncome = 0;
             const hungryNames = [];
+            const lostAnimals = [];
+            const newlySick = [];
+            const sickAnimals = [];
+            const updatedAnimals = [];
 
-            const updatedAnimals = prevAnimals.map(animal => {
+            prevAnimals.forEach(animal => {
               const animalData = ANIMALS[animal.type];
               const shelterKey = animalData.shelter;
               const hasShelter = buildings?.[shelterKey];
@@ -302,8 +326,14 @@ const FarmGame = () => {
               const previousHunger = animal.hunger ?? 60;
               const hunger = Math.max(0, previousHunger - 30);
 
+              if (hunger <= 0) {
+                lostAnimals.push(animal.name);
+                return;
+              }
+
               let happiness = Math.max(0, (animal.happiness ?? animalData.happiness) - 10);
               let canProduce = happiness > 20 && hunger > 30;
+              let sick = Boolean(animal.sick);
 
               if (hunger <= 10) {
                 hungryNames.push(`${animal.name}（急需餵食）`);
@@ -315,16 +345,28 @@ const FarmGame = () => {
                 canProduce = happiness > 25;
               }
 
+              if (!sick && (hunger <= 20 || happiness <= 20)) {
+                sick = true;
+                newlySick.push(animal.name);
+              }
+
+              if (sick) {
+                happiness = Math.max(0, happiness - 15);
+                canProduce = false;
+                sickAnimals.push(animal.name);
+              }
+
               const income = canProduce
                 ? Math.floor(animalData.income * boost * (happiness / 100))
                 : 0;
               totalIncome += income;
 
-              return {
+              updatedAnimals.push({
                 ...animal,
                 happiness,
                 hunger,
-              };
+                sick,
+              });
             });
 
             if (totalIncome > 0) {
@@ -337,8 +379,56 @@ const FarmGame = () => {
               addNotification(`🍽️ ${names} 肚子餓了，記得餵食！`, { type: 'warning' });
             }
 
+            if (lostAnimals.length > 0) {
+              const names = Array.from(new Set(lostAnimals)).join('、');
+              addNotification(`💀 ${names} 因為長期挨餓離開了農場……`, { type: 'error' });
+            }
+
+            if (newlySick.length > 0) {
+              const names = Array.from(new Set(newlySick)).join('、');
+              addNotification(`🤒 ${names} 身體不適，需要營養劑治療！`, { type: 'error' });
+            }
+
+            const ongoingSick = Array.from(new Set(sickAnimals.filter(name => !newlySick.includes(name))));
+            if (ongoingSick.length > 0) {
+              addNotification(`💊 ${ongoingSick.join('、')} 仍在療養中，記得使用營養劑。`, { type: 'warning' });
+            }
+
             return updatedAnimals;
           });
+
+          const infestedCrops = [];
+          setFarm(prevFarm => {
+            let changed = false;
+            const nextFarm = prevFarm.map(plot => {
+              let updatedPlot = plot;
+
+              if (plot.crop && !plot.ready && !plot.pest) {
+                const pestChance = plot.fertilized ? 0.05 : 0.12;
+                if (Math.random() < pestChance) {
+                  infestedCrops.push(CROPS[plot.crop].name);
+                  updatedPlot = { ...plot, pest: true };
+                }
+              }
+
+              if (!updatedPlot.crop && updatedPlot.fertilized) {
+                updatedPlot = { ...updatedPlot, fertilized: false };
+              }
+
+              if (updatedPlot !== plot) {
+                changed = true;
+              }
+
+              return updatedPlot;
+            });
+
+            return changed ? nextFarm : prevFarm;
+          });
+
+          if (infestedCrops.length > 0) {
+            const names = Array.from(new Set(infestedCrops)).join('、');
+            addNotification(`🐛 害蟲入侵！${names} 需要使用驅蟲劑。`, { type: 'warning' });
+          }
 
           return 6;
         }
@@ -373,12 +463,13 @@ const FarmGame = () => {
         if (plot.crop && plot.plantTime && !plot.pest) {
           const now = Date.now();
           const cropData = CROPS[plot.crop];
-          
+
           let weatherMultiplier = plot.greenhouse ? 1.2 : (cropData.weatherBonus[weather] || 1);
           const toolMultiplier = TOOLS[tools].speedBoost;
-          
-          const adjustedGrowTime = (cropData.growTime * 60000) / (weatherMultiplier * toolMultiplier);
-          
+          const fertilizerBoost = plot.fertilized ? 1.25 : 1;
+
+          const adjustedGrowTime = (cropData.growTime * 60000) / (weatherMultiplier * toolMultiplier * fertilizerBoost);
+
           if (now - plot.plantTime >= adjustedGrowTime && !plot.ready) {
             addNotification(`${cropData.emoji} ${cropData.name} 成熟了！`, { type: 'success' });
             return { ...plot, ready: true };
@@ -430,6 +521,20 @@ const FarmGame = () => {
 
   const feedAnimal = useCallback((animalId) => {
     gameEngine.feedAnimal(animalId);
+  }, [gameEngine]);
+
+  const buySupply = useCallback((supplyType) => {
+    gameEngine.buySupply(supplyType);
+  }, [gameEngine]);
+
+  const selectSupply = useCallback((supplyType) => {
+    gameEngine.selectSupply(supplyType);
+  }, [gameEngine]);
+
+  const applySupply = useCallback((plotId) => gameEngine.applySupply(plotId), [gameEngine]);
+
+  const treatAnimal = useCallback((animalId) => {
+    gameEngine.treatAnimal(animalId);
   }, [gameEngine]);
 
   const interactNPC = (npc) => {
@@ -562,16 +667,23 @@ const FarmGame = () => {
             {/* 農場格子 */}
             <div className="grid grid-cols-5 gap-2 mb-4">
               {farm.map((plot) => (
-                <div key={plot.id} 
+                <div key={plot.id}
                      className={`aspect-square border-2 rounded-lg cursor-pointer transition-all duration-300 hover:scale-105 relative ${
                        plot.greenhouse ? 'border-green-600 bg-green-50' :
-                       plot.crop 
-                         ? plot.ready 
-                           ? 'bg-green-200 border-green-400 animate-pulse' 
+                       plot.crop
+                         ? plot.ready
+                           ? 'bg-green-200 border-green-400 animate-pulse'
                            : 'bg-yellow-100 border-yellow-400'
                          : 'bg-gray-100 border-gray-300 hover:bg-green-50'
                      }`}
                      onClick={() => {
+                       if (selectedSupply) {
+                         const handled = applySupply(plot.id);
+                         if (handled) {
+                           return;
+                         }
+                       }
+
                        if (plot.crop && plot.ready) {
                          harvestCrop(plot.id);
                        } else if (!plot.crop && selectedSeed) {
@@ -586,6 +698,9 @@ const FarmGame = () => {
                     )}
                     {plot.pest && (
                       <div className="absolute top-0 left-0 text-xs animate-bounce">🐛</div>
+                    )}
+                    {plot.fertilized && !plot.ready && (
+                      <div className="absolute bottom-1 right-1 text-xs">🌿</div>
                     )}
                     {plot.crop ? (
                       <>
@@ -632,15 +747,24 @@ const FarmGame = () => {
                     const hasBuilding = buildings[animalData.shelter];
                     const hunger = animal.hunger ?? 50;
                     const isHungry = hunger <= 30;
+                    const isSick = Boolean(animal.sick);
+                    const medicineCount = farmSupplies.medicine || 0;
                     return (
                       <div key={animal.id}
-                           className={`rounded-lg p-3 transition-colors relative ${
-                             hasBuilding ? 'bg-green-100 hover:bg-green-200' : 'bg-blue-100 hover:bg-blue-200'
+                           className={`rounded-lg p-3 transition-colors relative border ${
+                             isSick
+                               ? 'border-red-300 bg-red-100 hover:bg-red-200'
+                               : hasBuilding
+                                 ? 'border-green-200 bg-green-100 hover:bg-green-200'
+                                 : 'border-blue-200 bg-blue-100 hover:bg-blue-200'
                            }`}>
                         {hasBuilding && (
                           <div className="absolute top-1 right-1 text-xs">
                             {BUILDINGS[animalData.shelter].emoji}
                           </div>
+                        )}
+                        {isSick && (
+                          <div className="absolute top-1 left-1 text-xs animate-pulse">🤒</div>
                         )}
                         <div className="text-center space-y-2">
                           <div className="text-3xl animate-bounce">
@@ -678,6 +802,22 @@ const FarmGame = () => {
                           </button>
                           {isHungry && (
                             <div className="text-xs text-orange-600">肚子餓扁了，快餵我！</div>
+                          )}
+                          {isSick && (
+                            <div className="mt-2 space-y-1">
+                              <button
+                                onClick={() => treatAnimal(animal.id)}
+                                disabled={medicineCount === 0}
+                                className={`w-full text-xs font-semibold py-1 rounded transition-colors ${
+                                  medicineCount > 0
+                                    ? 'bg-teal-500 hover:bg-teal-600 text-white'
+                                    : 'bg-teal-100 text-teal-700 cursor-not-allowed'
+                                }`}
+                              >
+                                治療 {medicineCount > 0 ? `(剩餘 ${medicineCount})` : '(需要營養劑)'}
+                              </button>
+                              <div className="text-xs text-red-500">身體不適，產出暫停中。</div>
+                            </div>
                           )}
                         </div>
                       </div>
@@ -724,6 +864,10 @@ const FarmGame = () => {
                   <Hammer className="mr-2 w-4 h-4" />
                   工具商店
                 </button>
+                <button onClick={() => setShowSupplyShop(true)}
+                        className="w-full bg-teal-500 hover:bg-teal-600 text-white py-2 px-4 rounded transition-colors flex items-center justify-center text-sm">
+                  🌿 農務用品
+                </button>
               </div>
             </div>
 
@@ -758,6 +902,52 @@ const FarmGame = () => {
               ))}
               {Object.values(inventory).every(count => count === 0) && (
                 <p className="text-gray-500 text-sm">庫存為空</p>
+              )}
+            </div>
+
+            {/* 農務用品 */}
+            <div className="bg-white bg-opacity-90 rounded-lg p-4 shadow-lg">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-lg font-bold">農務用品</h3>
+                <span className="text-xs text-gray-500">點擊選擇使用</span>
+              </div>
+              <div className="space-y-2">
+                {Object.entries(FARM_SUPPLIES).map(([key, supply]) => {
+                  const count = farmSupplies[key] || 0;
+                  const isSelected = selectedSupply === key;
+                  const isOut = count === 0;
+                  const disabled = isOut && key !== 'medicine';
+                  return (
+                    <button
+                      key={key}
+                      onClick={() => selectSupply(key)}
+                      disabled={disabled}
+                      className={`w-full flex items-center justify-between text-sm border rounded-lg px-3 py-2 transition-colors ${
+                        isSelected ? 'border-teal-500 bg-teal-50 text-teal-700' : 'border-gray-200 hover:border-teal-300'
+                      } ${isOut ? 'opacity-70 cursor-not-allowed' : ''}`}
+                    >
+                      <span className="flex items-center gap-2">
+                        <span>{supply.emoji}</span>
+                        <span className="font-semibold">{supply.name}</span>
+                      </span>
+                      <span className="text-xs text-gray-600">庫存 {count}</span>
+                    </button>
+                  );
+                })}
+              </div>
+              {selectedSupply && FARM_SUPPLIES[selectedSupply] && (
+                <div className="mt-2 space-y-1">
+                  <p className="text-xs text-teal-700">目前選擇：{FARM_SUPPLIES[selectedSupply].name}</p>
+                  <button
+                    onClick={() => setSelectedSupply(null)}
+                    className="text-[11px] text-teal-600 hover:text-teal-800"
+                  >
+                    取消選擇
+                  </button>
+                </div>
+              )}
+              {Object.values(farmSupplies).every(count => count === 0) && (
+                <p className="text-xs text-gray-500 mt-2">沒有庫存？到農務用品購買吧！</p>
               )}
             </div>
 
@@ -815,6 +1005,7 @@ const FarmGame = () => {
                   <li>到「種子商店」買種子，在農田空格種下會消耗體力。</li>
                   <li>不同作物有不同成長時間，天氣與工具等級會改變速度。</li>
                   <li>澆水、在溫室種植或擁有筒倉，都能提高售價。</li>
+                  <li>農務用品提供肥料與驅蟲劑，肥料能縮短成熟時間，害蟲會讓作物暫停生長。</li>
                   <li>例子：玉米基準價 $50，若有澆水（+20%）又在溫室（+50%），收成價約可達 $90。</li>
                 </ul>
               </section>
@@ -824,6 +1015,7 @@ const FarmGame = () => {
                   <li>在「動物商店」購買，部分動物需要先蓋對應建築。</li>
                   <li>每天餵食會扣飼料費，但能維持快樂度（最高 100）。</li>
                   <li>快樂度越高，產出的金幣越多；建築會提供額外加成。</li>
+                  <li>動物長期飢餓或心情低落會生病，產出停擺，記得準備營養劑治療。</li>
                 </ul>
               </section>
               <section>
@@ -1016,6 +1208,35 @@ const FarmGame = () => {
               ))}
             </div>
             <button onClick={() => setShowToolShop(false)}
+                    className="mt-4 w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded transition-colors">
+              關閉
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 農務用品商店 */}
+      {showSupplyShop && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
+            <h2 className="text-xl font-bold mb-4">農務用品商店</h2>
+            <div className="space-y-4">
+              {Object.entries(FARM_SUPPLIES).map(([key, supply]) => (
+                <div key={key}
+                     className="border rounded-lg p-4 cursor-pointer hover:bg-teal-50 transition-colors"
+                     onClick={() => buySupply(key)}>
+                  <div className="flex justify-between items-start">
+                    <div>
+                      <div className="text-2xl">{supply.emoji}</div>
+                      <div className="font-semibold mt-1">{supply.name}</div>
+                      <div className="text-sm text-gray-600 mt-1 leading-snug">{supply.description}</div>
+                    </div>
+                    <div className="text-green-600 font-bold">${supply.price}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <button onClick={() => setShowSupplyShop(false)}
                     className="mt-4 w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded transition-colors">
               關閉
             </button>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed } from 'lucide-react';
+import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed, TrendingUp, TrendingDown, Clock3, Boxes } from 'lucide-react';
 import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from './game/data/GameCatalog';
 import { GameFormatter } from './game/utils/GameFormatter';
 import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY } from './game/engine/GameEngine';
@@ -103,6 +103,8 @@ const FarmGame = () => {
   const [completedAchievements, setCompletedAchievements] = useState(new Set());
   const [aiAdvice, setAiAdvice] = useState('');
   const [marketPrices, setMarketPrices] = useState({});
+  const [previousMarketPrices, setPreviousMarketPrices] = useState({});
+  const [marketUpdateTime, setMarketUpdateTime] = useState(null);
   const [dailyStats, setDailyStats] = useState([]);
   const [automation, setAutomation] = useState({ autoWater: false, autoHarvest: false });
   
@@ -140,6 +142,8 @@ const FarmGame = () => {
     dailyStats,
     automation,
     marketPrices,
+    previousMarketPrices,
+    marketUpdateTime,
     saveSlots,
     selectedSeed,
     selectedSupply,
@@ -169,6 +173,8 @@ const FarmGame = () => {
       setDailyStats,
       setAutomation,
       setMarketPrices,
+      setPreviousMarketPrices,
+      setMarketUpdateTime,
       setSaveSlots,
       setShowSaveMenu,
       setShowLoadMenu,
@@ -203,7 +209,111 @@ const FarmGame = () => {
       setShowToolShop,
     },
     notifier: addNotification,
-  }), [addNotification]);
+  }), [stateRef, addNotification]);
+
+  const marketInsights = useMemo(() => {
+    const entries = Object.entries(CROPS).map(([key, crop]) => {
+      const price = marketPrices?.[key] ?? crop.sellPrice;
+      const basePrice = crop.sellPrice;
+      const previousPrice = previousMarketPrices?.[key];
+      const changeFromBase = price - basePrice;
+      const percentFromBase = basePrice ? (changeFromBase / basePrice) * 100 : 0;
+      const changeFromPrevious = typeof previousPrice === 'number' ? price - previousPrice : null;
+      const percentFromPrevious =
+        typeof previousPrice === 'number' && previousPrice !== 0
+          ? (changeFromPrevious / previousPrice) * 100
+          : null;
+
+      return {
+        key,
+        name: crop.name,
+        emoji: crop.emoji,
+        price,
+        basePrice,
+        changeFromBase,
+        percentFromBase,
+        previousPrice,
+        changeFromPrevious,
+        percentFromPrevious,
+      };
+    });
+
+    const sortedByPremium = [...entries].sort((a, b) => b.percentFromBase - a.percentFromBase);
+    const risers = entries
+      .filter(entry => (entry.changeFromPrevious ?? 0) > 0)
+      .sort((a, b) => (b.changeFromPrevious ?? 0) - (a.changeFromPrevious ?? 0))
+      .slice(0, 3);
+    const fallers = entries
+      .filter(entry => (entry.changeFromPrevious ?? 0) < 0)
+      .sort((a, b) => (a.changeFromPrevious ?? 0) - (b.changeFromPrevious ?? 0))
+      .slice(0, 3);
+    const averageIndex = entries.length > 0
+      ? entries.reduce((sum, entry) => sum + (entry.basePrice ? (entry.price / entry.basePrice) : 1), 0) / entries.length
+      : 1;
+    const highestPrice = entries.reduce((max, entry) => Math.max(max, entry.price), 0);
+
+    return {
+      entries,
+      sortedByPremium,
+      risers,
+      fallers,
+      averageIndex,
+      highestPrice,
+    };
+  }, [marketPrices, previousMarketPrices]);
+
+  const inventoryInsights = useMemo(() => {
+    const sourceInventory = inventory || {};
+    const items = [];
+    let totalCount = 0;
+    let totalValue = 0;
+
+    Object.entries(sourceInventory).forEach(([key, count]) => {
+      if (!count) return;
+      const metadata = INVENTORY_METADATA[key];
+      if (!metadata) return;
+
+      const totalItemValue = gameEngine.getInventorySaleValue(key, count);
+      const unitValue = count > 0 ? Math.max(0, Math.round(totalItemValue / count)) : 0;
+
+      totalCount += count;
+      totalValue += totalItemValue;
+
+      items.push({
+        key,
+        ...metadata,
+        count,
+        unitValue,
+        totalValue: totalItemValue,
+        canSell: totalItemValue > 0,
+      });
+    });
+
+    const sortedItems = items.sort((a, b) => {
+      if (b.totalValue === a.totalValue) {
+        return b.count - a.count;
+      }
+      return b.totalValue - a.totalValue;
+    });
+
+    const safeTotalValue = totalValue;
+    const safeTotalCount = totalCount;
+    sortedItems.forEach(item => {
+      if (safeTotalValue > 0) {
+        item.share = Math.round((item.totalValue / safeTotalValue) * 100);
+      } else if (safeTotalCount > 0) {
+        item.share = Math.round((item.count / safeTotalCount) * 100);
+      } else {
+        item.share = 0;
+      }
+    });
+
+    return {
+      items: sortedItems,
+      totalCount: safeTotalCount,
+      totalValue: Math.round(safeTotalValue),
+    };
+  }, [inventory, gameEngine, animals, buildings, marketPrices]);
 
   const saveToSlot = useCallback((slotName) => {
     saveManager.saveToSlot(slotName);
@@ -268,19 +378,22 @@ const FarmGame = () => {
   // 動態市場價格
   useEffect(() => {
     const updatePrices = () => {
+      const previousSnapshot = stateRef.current.marketPrices || {};
       const newPrices = {};
       Object.keys(CROPS).forEach(crop => {
         const basePrice = CROPS[crop].sellPrice;
         const fluctuation = 0.8 + Math.random() * 0.4;
         newPrices[crop] = Math.floor(basePrice * fluctuation);
       });
+      setPreviousMarketPrices(previousSnapshot);
       setMarketPrices(newPrices);
+      setMarketUpdateTime(Date.now());
     };
-    
+
     updatePrices();
     const timer = setInterval(updatePrices, 120000);
     return () => clearInterval(timer);
-  }, []);
+  }, [stateRef]);
 
   // 成就系統
   useEffect(() => {
@@ -664,8 +777,16 @@ const FarmGame = () => {
     gameEngine.expandAnimalHousing();
   }, [gameEngine]);
 
-  const sellInventoryItem = useCallback((itemKey) => {
-    gameEngine.sellInventoryItem(itemKey);
+  const sellInventoryItem = useCallback((itemKey, quantity) => {
+    if (typeof quantity === 'number' && quantity <= 0) {
+      return;
+    }
+
+    if (typeof quantity === 'number') {
+      gameEngine.sellInventoryItem(itemKey, { quantity });
+    } else {
+      gameEngine.sellInventoryItem(itemKey);
+    }
   }, [gameEngine]);
 
   const buyAnimal = useCallback((animalType) => {
@@ -1071,57 +1192,183 @@ const FarmGame = () => {
 
             {/* 市場價格 */}
             <div className="bg-white bg-opacity-90 rounded-lg p-4 shadow-lg">
-              <h3 className="text-lg font-bold mb-3">市場價格</h3>
-              <div className="space-y-1">
-                {Object.entries(marketPrices).slice(0, 3).map(([crop, price]) => (
-                  <div key={crop} className="flex justify-between items-center text-sm">
-                    <span>{CROPS[crop].emoji} {CROPS[crop].name}</span>
-                    <span className={`font-semibold ${
-                      price > CROPS[crop].sellPrice ? 'text-green-600' : 
-                      price < CROPS[crop].sellPrice ? 'text-red-600' : 'text-gray-600'
-                    }`}>
-                      ${price}
-                    </span>
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-lg font-bold flex items-center gap-2">
+                  <TrendingUp className="w-4 h-4 text-green-600" />
+                  市場價格
+                </h3>
+                <div className="flex items-center gap-1 text-xs text-gray-500">
+                  <Clock3 className="w-3 h-3" />
+                  <span>{marketUpdateTime ? new Date(marketUpdateTime).toLocaleTimeString('zh-TW', { hour: '2-digit', minute: '2-digit' }) : '更新中…'}</span>
+                </div>
+              </div>
+              <div className="bg-slate-50 border border-slate-200 rounded-lg p-2 mb-3">
+                <div className="flex items-center justify-between text-xs text-slate-600">
+                  <span>平均行情指數</span>
+                  <span className={`font-semibold ${marketInsights.averageIndex >= 1 ? 'text-green-600' : 'text-red-600'}`}>
+                    {(marketInsights.averageIndex * 100).toFixed(0)}%
+                  </span>
+                </div>
+                <div className="bg-slate-200 h-1 rounded-full overflow-hidden mt-2">
+                  <div
+                    className={`${marketInsights.averageIndex >= 1 ? 'bg-green-400' : 'bg-red-400'} h-full transition-all`}
+                    style={{ width: `${Math.min(100, Math.max(6, marketInsights.averageIndex * 100))}%` }}
+                  ></div>
+                </div>
+              </div>
+              {marketInsights.risers.length > 0 && (
+                <div className="mb-3">
+                  <div className="flex items-center gap-1 text-xs font-semibold text-green-600 uppercase tracking-wide">
+                    <TrendingUp className="w-3 h-3" />
+                    漲勢領先
                   </div>
-                ))}
+                  <div className="mt-1 space-y-1">
+                    {marketInsights.risers.map(entry => {
+                      const percentText = entry.percentFromPrevious != null ? entry.percentFromPrevious.toFixed(1) : '—';
+                      const percentDisplay = percentText === '—' ? '—' : `${percentText}%`;
+                      return (
+                        <div key={`rise-${entry.key}`} className="flex items-center justify-between text-xs bg-green-50 border border-green-100 rounded px-2 py-1 text-green-700">
+                          <span>{entry.emoji} {entry.name}</span>
+                          <span>
+                            +${entry.changeFromPrevious} ({percentDisplay})
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+              {marketInsights.fallers.length > 0 && (
+                <div className="mb-3">
+                  <div className="flex items-center gap-1 text-xs font-semibold text-red-600 uppercase tracking-wide">
+                    <TrendingDown className="w-3 h-3" />
+                    價格回落
+                  </div>
+                  <div className="mt-1 space-y-1">
+                    {marketInsights.fallers.map(entry => {
+                      const percentText = entry.percentFromPrevious != null ? Math.abs(entry.percentFromPrevious).toFixed(1) : '—';
+                      const percentDisplay = percentText === '—' ? '—' : `${percentText}%`;
+                      return (
+                        <div key={`fall-${entry.key}`} className="flex items-center justify-between text-xs bg-red-50 border border-red-100 rounded px-2 py-1 text-red-700">
+                          <span>{entry.emoji} {entry.name}</span>
+                          <span>
+                            -${Math.abs(entry.changeFromPrevious)} ({percentDisplay})
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+              <div className="space-y-2 border-t border-slate-200 pt-2">
+                {marketInsights.sortedByPremium.slice(0, 5).map(entry => {
+                  const trend = entry.changeFromPrevious ?? 0;
+                  const trendClass = trend > 0 ? 'text-green-600' : trend < 0 ? 'text-red-600' : 'text-gray-500';
+                  const premiumClass = entry.changeFromBase > 0 ? 'text-green-600' : entry.changeFromBase < 0 ? 'text-red-600' : 'text-gray-600';
+                  const percentFromPrevious = entry.percentFromPrevious != null ? entry.percentFromPrevious.toFixed(1) : '—';
+                  const premiumPercent = `${entry.percentFromBase >= 0 ? '+' : ''}${entry.percentFromBase.toFixed(1)}%`;
+                  const priceShare = marketInsights.highestPrice > 0 ? Math.min(100, Math.max(6, (entry.price / marketInsights.highestPrice) * 100)) : 0;
+
+                  return (
+                    <div key={entry.key} className="rounded-lg border border-slate-200 p-2">
+                      <div className="flex justify-between items-center text-sm font-semibold text-slate-800">
+                        <span>{entry.emoji} {entry.name}</span>
+                        <span>${entry.price}</span>
+                      </div>
+                      <div className="flex justify-between text-xs mt-1 text-slate-500">
+                        <span>基準 ${entry.basePrice}</span>
+                        <span className={premiumClass}>
+                          {entry.changeFromBase >= 0 ? '+' : ''}{entry.changeFromBase} ({premiumPercent})
+                        </span>
+                      </div>
+                      <div className="flex justify-between text-xs mt-1">
+                        <span className={trendClass}>
+                          {trend > 0 ? `▲ +${trend}` : trend < 0 ? `▼ ${trend}` : '→ 持平'}
+                        </span>
+                        <span className={trendClass}>
+                          {percentFromPrevious !== '—' ? `${trend > 0 ? '+' : ''}${percentFromPrevious}%` : '—'}
+                        </span>
+                      </div>
+                      <div className="bg-slate-100 h-1 rounded-full overflow-hidden mt-2">
+                        <div
+                          className="bg-slate-400 h-full transition-all"
+                          style={{ width: `${priceShare}%` }}
+                        ></div>
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
 
             {/* 庫存 */}
             <div className="bg-white bg-opacity-90 rounded-lg p-4 shadow-lg">
-              <h3 className="text-lg font-bold mb-3">庫存</h3>
-              {INVENTORY_ORDER.map((key) => {
-                const count = inventory[key] || 0;
-                if (count <= 0) {
-                  return null;
-                }
+              <div className="flex items-start justify-between mb-3">
+                <div>
+                  <h3 className="text-lg font-bold flex items-center gap-2">
+                    <Boxes className="w-4 h-4 text-amber-600" />
+                    庫存
+                  </h3>
+                  <p className="text-xs text-gray-500 mt-1">動物產品與作物收成都集中在這裡管理。</p>
+                </div>
+                <div className="text-right text-xs">
+                  <div className="text-gray-500">共 {inventoryInsights.totalCount} 件</div>
+                  <div className="text-amber-600 font-semibold">估值 ${inventoryInsights.totalValue}</div>
+                </div>
+              </div>
+              {inventoryInsights.items.length > 0 ? (
+                <div className="space-y-2">
+                  {inventoryInsights.items.map(item => {
+                    const halfQuantity = Math.floor(item.count / 2);
+                    const shareWidth = item.share > 0 ? Math.min(100, Math.max(6, item.share)) : 0;
 
-                const item = INVENTORY_METADATA[key];
-                const saleValue = item.type === 'product' ? gameEngine.getInventorySaleValue(key, count) : 0;
-                const canSell = item.type === 'product' && saleValue > 0;
-
-                return (
-                  <div key={key} className="flex justify-between items-center py-1">
-                    <span>{item.emoji} {item.name}</span>
-                    <div className="flex items-center gap-2">
-                      <span className="font-semibold">{count}</span>
-                      {canSell && (
-                        <button
-                          onClick={() => sellInventoryItem(key)}
-                          className="text-xs bg-amber-500 hover:bg-amber-600 text-white px-2 py-1 rounded transition-colors"
-                        >
-                          出售（{'$'}{saleValue}）
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
-              {INVENTORY_ORDER.every(key => (inventory[key] || 0) === 0) && (
-                <p className="text-gray-500 text-sm">庫存為空</p>
-              )}
-              {Object.keys(ANIMAL_PRODUCTS).some(key => (inventory[key] || 0) > 0) && (
-                <p className="text-xs text-amber-600 mt-2">提示：雞蛋與鮮奶可在此處直接出售換現金！</p>
+                    return (
+                      <div key={item.key} className="rounded-lg border border-amber-200 bg-amber-50/80 p-3">
+                        <div className="flex justify-between items-start">
+                          <div className="flex items-center gap-3">
+                            <div className="text-2xl">{item.emoji}</div>
+                            <div>
+                              <div className="font-semibold text-sm text-amber-900">{item.name}</div>
+                              <div className="text-xs text-amber-700">
+                                {item.type === 'product' ? '畜產品' : '作物'} · 單價 ${item.unitValue}
+                              </div>
+                            </div>
+                          </div>
+                          <div className="text-right">
+                            <div className="font-bold text-sm text-amber-900">x{item.count}</div>
+                            <div className="text-xs text-amber-700">總值 ${item.totalValue}</div>
+                          </div>
+                        </div>
+                        <div className="bg-amber-100 h-1 rounded-full overflow-hidden mt-2">
+                          <div
+                            className="bg-amber-400 h-full transition-all"
+                            style={{ width: `${shareWidth}%` }}
+                          ></div>
+                        </div>
+                        {item.canSell && (
+                          <div className="flex justify-end gap-2 mt-2">
+                            {halfQuantity > 0 && halfQuantity < item.count && (
+                              <button
+                                onClick={() => sellInventoryItem(item.key, halfQuantity)}
+                                className="text-xs bg-white border border-amber-300 hover:border-amber-400 text-amber-700 px-2 py-1 rounded transition-colors"
+                              >
+                                出售 {halfQuantity} 個
+                              </button>
+                            )}
+                            <button
+                              onClick={() => sellInventoryItem(item.key)}
+                              className="text-xs bg-amber-500 hover:bg-amber-600 text-white px-2 py-1 rounded transition-colors"
+                            >
+                              全部出售（${item.totalValue}）
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-gray-500 text-sm">庫存為空，快去田裡收成或向動物們索取產品吧！</p>
               )}
             </div>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -405,6 +405,46 @@ const FarmGame = () => {
     };
   }, [inventory, gameEngine, animals, buildings, marketPrices, inventorySortMode]);
 
+  const seedStorage = useMemo(() => {
+    const sourceInventory = inventory || {};
+    if (!sourceInventory) {
+      return [];
+    }
+
+    return Object.entries(sourceInventory)
+      .map(([key, count]) => {
+        if (!key.startsWith('seed_')) {
+          return null;
+        }
+        const supplyCount = farmSupplies?.[key] || 0;
+        const totalCount = Math.max(count || 0, supplyCount || 0);
+        if (totalCount <= 0) {
+          return null;
+        }
+        const cropKey = key.replace('seed_', '');
+        const crop = CROPS[cropKey];
+        return {
+          key,
+          cropKey,
+          count: totalCount,
+          name: crop?.name || cropKey,
+          emoji: crop?.emoji || '🌱',
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => {
+        if (b.count === a.count) {
+          return a.name.localeCompare(b.name, 'zh-TW');
+        }
+        return b.count - a.count;
+      });
+  }, [inventory, farmSupplies]);
+
+  const hasAnyBaseSupply = useMemo(
+    () => Object.keys(FARM_SUPPLIES).some(key => (farmSupplies?.[key] || 0) > 0),
+    [farmSupplies],
+  );
+
   const buildingEntries = useMemo(() => {
     if (!buildings) {
       return [];
@@ -641,23 +681,29 @@ const FarmGame = () => {
                 sickAnimals.push(animal.name);
               }
 
-              let income = 0;
-              if (canProduce) {
-                if (animalData.product && ANIMAL_PRODUCTS[animalData.product]) {
-                  const productKey = animalData.product;
-                  const baseUnits = 1;
-                  const units = Math.max(1, Math.round(baseUnits * boost * (happiness / 100)));
-                  producedGoods[productKey] = (producedGoods[productKey] || 0) + units;
-                } else {
-                  income = Math.floor(animalData.income * boost * (happiness / 100));
-                }
+            let income = 0;
+            let productReady = Math.max(0, Math.floor(animal.productReady || 0));
+            if (canProduce) {
+              if (animalData.product && ANIMAL_PRODUCTS[animalData.product]) {
+                const productKey = animalData.product;
+                const baseUnits = 1;
+                const units = Math.max(1, Math.round(baseUnits * boost * (happiness / 100)));
+                productReady += units;
+                producedGoods[productKey] = (producedGoods[productKey] || 0) + units;
+              } else {
+                income = Math.floor(animalData.income * boost * (happiness / 100));
               }
-              totalIncome += income;
+            }
+            totalIncome += income;
 
-              if (!sick && hunger >= 75 && happiness >= 75 && newbornAnimals.length < 3) {
-                const birthChance = 0.12
-                  + (happiness > 90 ? 0.05 : 0)
-                  + (hunger > 90 ? 0.05 : 0);
+            if (!animalData.product) {
+              productReady = 0;
+            }
+
+            if (!sick && hunger >= 75 && happiness >= 75 && newbornAnimals.length < 3) {
+              const birthChance = 0.12
+                + (happiness > 90 ? 0.05 : 0)
+                + (hunger > 90 ? 0.05 : 0);
                 if (Math.random() < birthChance) {
                   typeCounts[animal.type] = (typeCounts[animal.type] || 0) + 1;
                   const baseName = animalData.name;
@@ -671,6 +717,7 @@ const FarmGame = () => {
                     lastFed: Date.now(),
                     sick: false,
                     name: babyName,
+                    productReady: 0,
                   });
                 }
               }
@@ -680,6 +727,7 @@ const FarmGame = () => {
                 happiness,
                 hunger,
                 sick,
+                productReady,
               });
             });
 
@@ -755,21 +803,13 @@ const FarmGame = () => {
           });
 
           if (Object.keys(producedGoods).length > 0) {
-            setInventory(prevInventory => {
-              const nextInventory = { ...prevInventory };
-              Object.entries(producedGoods).forEach(([productKey, amount]) => {
-                nextInventory[productKey] = (nextInventory[productKey] || 0) + amount;
-              });
-              return nextInventory;
-            });
-
             const produceSummary = Object.entries(producedGoods).map(([productKey, amount]) => {
               const product = ANIMAL_PRODUCTS[productKey];
               const label = product ? `${product.emoji} ${product.name}` : productKey;
               return `${label} x${amount}`;
             });
 
-            addNotification(`${produceSummary.join('、')} 入庫！可到庫存出售換現金。`, { type: 'info' });
+            addNotification(`${produceSummary.join('、')} 已可收集，記得到動物欄點擊「收集」！`, { type: 'info' });
           }
 
           const infestedCrops = [];
@@ -1070,6 +1110,10 @@ const FarmGame = () => {
 
   const feedAnimal = useCallback((animalId) => {
     gameEngine.feedAnimal(animalId);
+  }, [gameEngine]);
+
+  const collectAnimalProduct = useCallback((animalId) => {
+    gameEngine.collectAnimalProduct(animalId);
   }, [gameEngine]);
 
   const buySupply = useCallback((supplyType, quantity = 1) => {
@@ -1379,6 +1423,9 @@ const FarmGame = () => {
                     const isHungry = hunger <= 30;
                     const isSick = Boolean(animal.sick);
                     const medicineCount = farmSupplies.medicine || 0;
+                    const productInfo = animalData.product ? ANIMAL_PRODUCTS[animalData.product] : null;
+                    const readyCount = Math.max(0, Math.floor(animal.productReady || 0));
+                    const canCollectProduct = Boolean(productInfo) && readyCount > 0;
                     return (
                       <div key={animal.id}
                            className={`rounded-lg p-3 transition-colors relative border ${
@@ -1422,10 +1469,13 @@ const FarmGame = () => {
                                    style={{ width: `${Math.max(0, Math.min(100, hunger))}%` }}></div>
                             </div>
                           </div>
-                          {animalData.product && ANIMAL_PRODUCTS[animalData.product] ? (
+                          {productInfo ? (
                             <div className="text-xs text-amber-600">
-                              產物：{ANIMAL_PRODUCTS[animalData.product].emoji} {ANIMAL_PRODUCTS[animalData.product].name}
-                              <span className="ml-1 text-[10px] text-amber-500">（入庫可出售）</span>
+                              產物：{productInfo.emoji} {productInfo.name}
+                              {canCollectProduct && (
+                                <span className="ml-1 font-semibold text-amber-700">可收集 {readyCount}</span>
+                              )}
+                              <span className="ml-1 text-[10px] text-amber-500">（收集後可出售）</span>
                             </div>
                           ) : (
                             <div className="text-xs text-green-600">
@@ -1442,6 +1492,14 @@ const FarmGame = () => {
                           </button>
                           {isHungry && (
                             <div className="text-xs text-orange-600">肚子餓扁了，快餵我！</div>
+                          )}
+                          {canCollectProduct && (
+                            <button
+                              onClick={() => collectAnimalProduct(animal.id)}
+                              className="w-full text-xs font-semibold py-1 rounded transition-colors bg-amber-400 hover:bg-amber-500 text-amber-900 mt-2"
+                            >
+                              收集 {productInfo?.name || '產物'} (+{readyCount})
+                            </button>
                           )}
                           {isSick && (
                             <div className="mt-2 space-y-1">
@@ -1949,6 +2007,34 @@ const FarmGame = () => {
                   );
                 })}
               </div>
+              {seedStorage.length > 0 && (
+                <div className="mt-4 border-t border-teal-200 pt-3">
+                  <h4 className="text-sm font-semibold text-teal-700 mb-2">種子倉庫</h4>
+                  <div className="space-y-2">
+                    {seedStorage.map(seed => {
+                      const isSelected = selectedSeed === seed.cropKey;
+                      return (
+                        <button
+                          key={seed.key}
+                          onClick={() => prepareSeed(seed.cropKey)}
+                          className={`w-full flex items-center justify-between text-sm border rounded-lg px-3 py-2 transition-colors ${
+                            isSelected ? 'border-amber-500 bg-amber-50 text-amber-700' : 'border-amber-200 hover:border-amber-400'
+                          }`}
+                        >
+                          <span className="flex items-center gap-2">
+                            <span>{seed.emoji}</span>
+                            <span className="font-semibold">{seed.name} 種子</span>
+                          </span>
+                          <span className="text-xs text-gray-600">庫存 {seed.count} 包</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <p className="text-[11px] text-amber-600 mt-2">
+                    點擊即可帶著種子外出種植；庫存不足時系統會改為現金購買。
+                  </p>
+                </div>
+              )}
               {selectedSupply && FARM_SUPPLIES[selectedSupply] && (
                 <div className="mt-2 space-y-1">
                   <p className="text-xs text-teal-700">目前選擇：{FARM_SUPPLIES[selectedSupply].name}</p>
@@ -1960,7 +2046,7 @@ const FarmGame = () => {
                   </button>
                 </div>
               )}
-              {Object.values(farmSupplies).every(count => count === 0) && (
+              {!hasAnyBaseSupply && (
                 <p className="text-xs text-gray-500 mt-2">沒有庫存？到農務用品購買吧！</p>
               )}
             </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed, TrendingUp, TrendingDown, Clock3, Boxes } from 'lucide-react';
 import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from './game/data/GameCatalog';
 import { GameFormatter } from './game/utils/GameFormatter';
-import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY } from './game/engine/GameEngine';
+import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, FARM_EXPANSION_BATCH, ANIMAL_CAPACITY_STEP } from './game/engine/GameEngine';
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
 
@@ -56,6 +56,8 @@ const FarmGame = () => {
     medicine: 0,
   });
 
+  const [questLog, setQuestLog] = useState({});
+
   const [animals, setAnimals] = useState([]);
   const [animalCapacity, setAnimalCapacity] = useState(BASE_ANIMAL_CAPACITY);
   const [buildings, setBuildings] = useState({});
@@ -81,6 +83,41 @@ const FarmGame = () => {
   const [marketView, setMarketView] = useState('summary');
   const [marketListSort, setMarketListSort] = useState('price');
   const [inventorySortMode, setInventorySortMode] = useState('value');
+
+  const questDefinitions = useMemo(() => {
+    const map = {};
+    NPCS.forEach(npc => {
+      (npc.quests || []).forEach(quest => {
+        if (quest?.id) {
+          map[quest.id] = { ...quest, npcName: npc.name };
+        }
+      });
+    });
+    return map;
+  }, []);
+
+  const getQuestTargetLabel = useCallback((quest) => {
+    if (!quest?.target) {
+      return '目標';
+    }
+
+    if (CROPS[quest.target]) {
+      const crop = CROPS[quest.target];
+      return `${crop.emoji} ${crop.name}`;
+    }
+
+    if (ANIMAL_PRODUCTS[quest.target]) {
+      const product = ANIMAL_PRODUCTS[quest.target];
+      return `${product.emoji} ${product.name}`;
+    }
+
+    if (FARM_SUPPLIES[quest.target]) {
+      const supply = FARM_SUPPLIES[quest.target];
+      return `${supply.emoji} ${supply.name}`;
+    }
+
+    return quest.target;
+  }, []);
 
   const notificationCenter = useMemo(() => new NotificationCenter(setNotifications), []);
   const addNotification = useCallback((message, options) => {
@@ -138,6 +175,7 @@ const FarmGame = () => {
     inventory,
     farm,
     farmSupplies,
+    questLog,
     animals,
     animalCapacity,
     buildings,
@@ -177,6 +215,7 @@ const FarmGame = () => {
       setBuildings,
       setTools,
       setFarmSupplies,
+      setQuestLog,
       setCompletedAchievements,
       setDailyStats,
       setAutomation,
@@ -195,6 +234,81 @@ const FarmGame = () => {
     },
     notifier: addNotification,
   }), [addNotification]);
+
+  const recordQuestEvent = useCallback((event) => {
+    if (!event?.type) {
+      return;
+    }
+
+    setQuestLog(prev => {
+      if (!prev || Object.keys(prev).length === 0) {
+        return prev;
+      }
+
+      let mutated = false;
+      const next = { ...prev };
+
+      Object.entries(prev).forEach(([questId, entry]) => {
+        if (!entry || (entry.status !== 'accepted' && entry.status !== 'ready')) {
+          return;
+        }
+
+        const quest = questDefinitions[questId];
+        if (!quest) {
+          return;
+        }
+
+        const required = quest.count ?? 0;
+        const currentProgress = entry.progress ?? 0;
+        let updatedEntry = entry;
+
+        switch (quest.type) {
+          case 'harvest':
+            if (event.type === 'harvest' && event.crop === quest.target) {
+              const newProgress = Math.min(required, currentProgress + (event.amount ?? 1));
+              if (newProgress !== currentProgress || entry.status !== 'ready') {
+                updatedEntry = { ...entry, progress: newProgress };
+                if (required > 0 && newProgress >= required) {
+                  updatedEntry.status = 'ready';
+                }
+              }
+            }
+            break;
+          case 'sell':
+            if (event.type === 'sell' && event.crop === quest.target) {
+              const newProgress = Math.min(required, currentProgress + (event.amount ?? 1));
+              if (newProgress !== currentProgress || entry.status !== 'ready') {
+                updatedEntry = { ...entry, progress: newProgress };
+                if (required > 0 && newProgress >= required) {
+                  updatedEntry.status = 'ready';
+                }
+              }
+            }
+            break;
+          case 'pestClear':
+            if (event.type === 'pestClear') {
+              const newProgress = Math.min(required, currentProgress + (event.amount ?? 1));
+              if (newProgress !== currentProgress || entry.status !== 'ready') {
+                updatedEntry = { ...entry, progress: newProgress };
+                if (required > 0 && newProgress >= required) {
+                  updatedEntry.status = 'ready';
+                }
+              }
+            }
+            break;
+          default:
+            break;
+        }
+
+        if (updatedEntry !== entry) {
+          next[questId] = updatedEntry;
+          mutated = true;
+        }
+      });
+
+      return mutated ? next : prev;
+    });
+  }, [questDefinitions]);
 
   const gameEngine = useMemo(() => new GameEngine({
     stateRef,
@@ -217,9 +331,152 @@ const FarmGame = () => {
       setTools,
       setShowToolShop,
       setPendingGreenhousePlacement,
+      recordQuestEvent,
     },
     notifier: addNotification,
-  }), [stateRef, addNotification]);
+  }), [stateRef, addNotification, recordQuestEvent]);
+
+  const acceptQuest = useCallback((questId) => {
+    const quest = questDefinitions[questId];
+    if (!quest) {
+      return;
+    }
+
+    const existing = questLog[questId];
+    if (existing?.status === 'accepted' || existing?.status === 'ready') {
+      addNotification('任務已在進行中！', { type: 'info' });
+      return;
+    }
+    if (existing?.status === 'completed') {
+      addNotification('這項任務已經完成過囉！', { type: 'info' });
+      return;
+    }
+
+    setQuestLog(prev => ({
+      ...prev,
+      [questId]: {
+        status: 'accepted',
+        progress: 0,
+        acceptedDay: day,
+      },
+    }));
+    addNotification(`📜 接下任務：「${quest.description}」`, { type: 'info' });
+  }, [questDefinitions, questLog, setQuestLog, addNotification, day]);
+
+  const deliverQuest = useCallback((questId) => {
+    const quest = questDefinitions[questId];
+    if (!quest || quest.type !== 'deliver') {
+      return;
+    }
+
+    const entry = questLog[questId];
+    if (!entry || entry.status !== 'accepted') {
+      if (entry?.status === 'completed') {
+        addNotification('任務已經交付完成。', { type: 'info' });
+      } else {
+        addNotification('請先接受任務再進行交付。', { type: 'warning' });
+      }
+      return;
+    }
+
+    const needCount = quest.count ?? 0;
+    const available = inventory?.[quest.target] ?? 0;
+    if (available < needCount) {
+      addNotification('庫存不足，無法完成交付。', { type: 'warning' });
+      return;
+    }
+
+    setInventory(prev => ({
+      ...prev,
+      [quest.target]: Math.max(0, (prev?.[quest.target] || 0) - needCount),
+    }));
+    setMoney(prev => prev + (quest.reward ?? 0));
+    setQuestLog(prev => ({
+      ...prev,
+      [questId]: {
+        ...prev[questId],
+        status: 'completed',
+        progress: needCount,
+        completedDay: day,
+      },
+    }));
+
+    const targetLabel = getQuestTargetLabel(quest);
+    addNotification(`🎁 已交付 ${needCount} 份${targetLabel}，獲得 $${quest.reward}！`, { type: 'success' });
+  }, [questDefinitions, questLog, inventory, setInventory, setMoney, setQuestLog, getQuestTargetLabel, addNotification, day]);
+
+  const claimQuestReward = useCallback((questId) => {
+    const quest = questDefinitions[questId];
+    if (!quest) {
+      return;
+    }
+
+    const entry = questLog[questId];
+    if (!entry) {
+      addNotification('請先接受任務！', { type: 'info' });
+      return;
+    }
+
+    if (entry.status !== 'ready') {
+      if (entry.status === 'completed') {
+        addNotification('任務獎勵已經領取過了。', { type: 'info' });
+      } else {
+        addNotification('仍未達成任務要求，持續加油！', { type: 'warning' });
+      }
+      return;
+    }
+
+    setMoney(prev => prev + (quest.reward ?? 0));
+    setQuestLog(prev => ({
+      ...prev,
+      [questId]: {
+        ...prev[questId],
+        status: 'completed',
+        progress: quest.count ?? prev[questId]?.progress ?? 0,
+        completedDay: day,
+      },
+    }));
+    addNotification(`💰 領取任務獎勵 $${quest.reward}！`, { type: 'success' });
+  }, [questDefinitions, questLog, setMoney, setQuestLog, addNotification, day]);
+
+  const activeQuests = useMemo(() => {
+    if (!questLog) {
+      return [];
+    }
+
+    return Object.entries(questLog)
+      .map(([questId, entry]) => {
+        const quest = questDefinitions[questId];
+        if (!quest || entry.status === 'completed') {
+          return null;
+        }
+
+        const required = quest.count ?? 0;
+        const inventoryCount = quest.type === 'deliver' ? (inventory?.[quest.target] ?? 0) : null;
+        const progress = quest.type === 'deliver'
+          ? Math.min(required, inventoryCount ?? 0)
+          : Math.min(required, entry.progress ?? 0);
+        const ready = entry.status === 'ready'
+          || (quest.type === 'deliver' && entry.status === 'accepted' && inventoryCount != null && inventoryCount >= required);
+
+        return {
+          id: questId,
+          quest,
+          entry,
+          progress,
+          required,
+          ready,
+          inventoryCount,
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => {
+        if (a.ready === b.ready) {
+          return 0;
+        }
+        return a.ready ? -1 : 1;
+      });
+  }, [questLog, questDefinitions, inventory]);
 
   const marketInsights = useMemo(() => {
     const entries = Object.entries(CROPS).map(([key, crop]) => {
@@ -612,6 +869,39 @@ const FarmGame = () => {
               });
             });
 
+            let processedAnimals = updatedAnimals;
+            const outbreakVictims = [];
+            if (processedAnimals.length > 0 && Math.random() < 0.08) {
+              const healthyCandidates = processedAnimals.filter(candidate => !candidate.sick);
+              if (healthyCandidates.length > 0) {
+                const victimCount = Math.max(1, Math.ceil(healthyCandidates.length * 0.3));
+                const selectedIds = new Set();
+                while (selectedIds.size < Math.min(victimCount, healthyCandidates.length)) {
+                  const target = healthyCandidates[Math.floor(Math.random() * healthyCandidates.length)];
+                  selectedIds.add(target.id);
+                }
+
+                processedAnimals = processedAnimals.map(state => {
+                  if (selectedIds.has(state.id)) {
+                    const animalData = ANIMALS[state.type];
+                    const baseHappiness = state.happiness ?? animalData.happiness ?? 40;
+                    const baseHunger = state.hunger ?? 60;
+                    const adjusted = {
+                      ...state,
+                      sick: true,
+                      happiness: Math.max(0, baseHappiness - 20),
+                      hunger: Math.max(0, baseHunger - 25),
+                    };
+                    outbreakVictims.push(adjusted.name);
+                    newlySick.push(adjusted.name);
+                    sickAnimals.push(adjusted.name);
+                    return adjusted;
+                  }
+                  return state;
+                });
+              }
+            }
+
             if (totalIncome > 0) {
               setMoney(prevMoney => prevMoney + totalIncome);
               addNotification(`🐾 動物們帶來了 $${totalIncome} 的收入！`, { type: 'success' });
@@ -632,6 +922,11 @@ const FarmGame = () => {
               addNotification(`🤒 ${names} 身體不適，需要營養劑治療！`, { type: 'error' });
             }
 
+            if (outbreakVictims.length > 0) {
+              const names = Array.from(new Set(outbreakVictims)).join('、');
+              addNotification(`☠️ 農場爆發傳染病！${names} 情況危急，務必立即治療！`, { type: 'error' });
+            }
+
             const ongoingSick = Array.from(new Set(sickAnimals.filter(name => !newlySick.includes(name))));
             if (ongoingSick.length > 0) {
               addNotification(`💊 ${ongoingSick.join('、')} 仍在療養中，記得使用營養劑。`, { type: 'warning' });
@@ -642,7 +937,7 @@ const FarmGame = () => {
               addNotification(`🐣 ${names} 出生了，農場又更熱鬧了！`, { type: 'success' });
             }
 
-            return [...updatedAnimals, ...newbornAnimals];
+            return [...processedAnimals, ...newbornAnimals];
           });
 
           if (Object.keys(producedGoods).length > 0) {
@@ -665,6 +960,8 @@ const FarmGame = () => {
 
           const infestedCrops = [];
           const destroyedCrops = [];
+          const stormDamaged = [];
+          const blightInfected = [];
           const autoWatered = new Set();
           setFarm(prevFarm => {
             let changed = false;
@@ -735,7 +1032,68 @@ const FarmGame = () => {
               return updatedPlot;
             });
 
-            return changed ? nextFarm : prevFarm;
+            let processedFarm = nextFarm;
+
+            const vulnerableForStorm = processedFarm.filter(plot => plot.crop && !plot.greenhouse);
+            if (vulnerableForStorm.length > 0 && Math.random() < 0.12) {
+              const hits = Math.max(1, Math.ceil(vulnerableForStorm.length * 0.25));
+              const selectedIds = new Set();
+              while (selectedIds.size < Math.min(hits, vulnerableForStorm.length)) {
+                const target = vulnerableForStorm[Math.floor(Math.random() * vulnerableForStorm.length)];
+                selectedIds.add(target.id);
+              }
+
+              processedFarm = processedFarm.map(plot => {
+                if (selectedIds.has(plot.id)) {
+                  const cropInfo = plot.crop ? CROPS[plot.crop] : null;
+                  if (cropInfo) {
+                    stormDamaged.push(cropInfo.name);
+                  }
+                  changed = true;
+                  return {
+                    ...plot,
+                    crop: null,
+                    plantTime: null,
+                    watered: false,
+                    fertilized: false,
+                    pest: false,
+                    pestDays: 0,
+                    ready: false,
+                  };
+                }
+                return plot;
+              });
+            }
+
+            const vulnerableForBlight = processedFarm.filter(plot => plot.crop && !plot.greenhouse && !plot.ready && !plot.pest);
+            if (vulnerableForBlight.length > 0 && Math.random() < 0.09) {
+              const hits = Math.max(1, Math.ceil(vulnerableForBlight.length * 0.3));
+              const selectedIds = new Set();
+              while (selectedIds.size < Math.min(hits, vulnerableForBlight.length)) {
+                const target = vulnerableForBlight[Math.floor(Math.random() * vulnerableForBlight.length)];
+                selectedIds.add(target.id);
+              }
+
+              processedFarm = processedFarm.map(plot => {
+                if (selectedIds.has(plot.id)) {
+                  const cropInfo = plot.crop ? CROPS[plot.crop] : null;
+                  if (cropInfo) {
+                    blightInfected.push(cropInfo.name);
+                  }
+                  changed = true;
+                  return {
+                    ...plot,
+                    pest: true,
+                    pestDays: Math.max(2, (plot.pestDays ?? 0) + 2),
+                    watered: false,
+                    fertilized: false,
+                  };
+                }
+                return plot;
+              });
+            }
+
+            return changed ? processedFarm : prevFarm;
           });
 
           if (infestedCrops.length > 0) {
@@ -746,6 +1104,16 @@ const FarmGame = () => {
           if (destroyedCrops.length > 0) {
             const names = Array.from(new Set(destroyedCrops)).join('、');
             addNotification(`🥀 ${names} 因害蟲侵蝕而枯萎了……記得提早使用除蟲劑。`, { type: 'error' });
+          }
+
+          if (stormDamaged.length > 0) {
+            const names = Array.from(new Set(stormDamaged)).join('、');
+            addNotification(`⛈️ 暴風雨摧毀了 ${names}，未設溫室的作物損失慘重！`, { type: 'error' });
+          }
+
+          if (blightInfected.length > 0) {
+            const names = Array.from(new Set(blightInfected)).join('、');
+            addNotification(`🦠 ${names} 感染了作物病害，快使用除蟲劑或移入溫室！`, { type: 'warning' });
           }
 
           if (autoWatered.size > 0) {
@@ -1111,7 +1479,7 @@ const FarmGame = () => {
                   onClick={expandFarmPlots}
                   className="self-start sm:self-auto bg-green-500 hover:bg-green-600 text-white px-3 py-1 rounded transition-colors"
                 >
-                  擴建農地（{'$'}{nextFarmExpansionCost}）
+                  擴建農地（{'$'}{nextFarmExpansionCost} / +{FARM_EXPANSION_BATCH}格）
                 </button>
               ) : (
                 <span className="text-xs text-gray-500">農地已達最大規模</span>
@@ -1146,7 +1514,7 @@ const FarmGame = () => {
                     onClick={expandAnimalPens}
                     className="self-start sm:self-auto bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded transition-colors"
                   >
-                    擴建動物欄（{'$'}{nextAnimalExpansionCost}）
+                    擴建動物欄（{'$'}{nextAnimalExpansionCost} / +{ANIMAL_CAPACITY_STEP}格）
                   </button>
                 ) : (
                   <span className="text-xs text-gray-500">動物欄位已達上限</span>
@@ -1290,6 +1658,79 @@ const FarmGame = () => {
                   🌿 農務用品
                 </button>
               </div>
+            </div>
+
+            {/* 任務告示板 */}
+            <div className="bg-white bg-opacity-90 rounded-lg p-4 shadow-lg">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-lg font-bold flex items-center gap-2">
+                  <Target className="w-4 h-4 text-rose-600" />
+                  任務告示板
+                </h3>
+                <span className="text-xs text-gray-500">進行中 {activeQuests.length}</span>
+              </div>
+              {activeQuests.length > 0 ? (
+                <div className="space-y-2">
+                  {activeQuests.map(({ id, quest, entry, progress, required, ready, inventoryCount }) => {
+                    const badgeText = ready ? '可完成' : entry.status === 'accepted' ? '進行中' : '等待交付';
+                    const badgeClass = ready ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600';
+                    const targetLabel = getQuestTargetLabel(quest);
+                    const needsText = required > 0 ? `需求：${targetLabel} x${required}` : '';
+                    const progressText = required > 0
+                      ? quest.type === 'deliver'
+                        ? `庫存 ${inventoryCount ?? 0}/${required}`
+                        : `進度 ${progress}/${required}`
+                      : '';
+
+                    return (
+                      <div key={id} className="border border-rose-100 rounded-lg p-3 bg-rose-50/70">
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <p className="text-sm font-semibold text-rose-700 leading-snug">{quest.description}</p>
+                            <p className="text-xs text-gray-600 mt-1">獎勵 ${quest.reward}</p>
+                            {needsText && (
+                              <p className="text-xs text-gray-500 mt-1">{needsText}</p>
+                            )}
+                            {progressText && (
+                              <p className="text-xs text-gray-500">{progressText}</p>
+                            )}
+                          </div>
+                          <span className={`text-[11px] px-2 py-1 rounded-full ${badgeClass}`}>{badgeText}</span>
+                        </div>
+                        <div className="mt-2 flex justify-end">
+                          {quest.type === 'deliver' ? (
+                            <button
+                              onClick={() => deliverQuest(id)}
+                              disabled={!ready}
+                              className={`text-xs font-semibold px-3 py-1 rounded transition-colors ${ready
+                                ? 'bg-rose-500 text-white hover:bg-rose-600'
+                                : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                              }`}
+                            >
+                              交付
+                            </button>
+                          ) : (
+                            <button
+                              onClick={() => claimQuestReward(id)}
+                              disabled={!ready}
+                              className={`text-xs font-semibold px-3 py-1 rounded transition-colors ${ready
+                                ? 'bg-emerald-500 text-white hover:bg-emerald-600'
+                                : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                              }`}
+                            >
+                              領取獎勵
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">
+                  目前沒有進行中的任務，去和鄰居聊聊看看是否需要幫忙吧！
+                </p>
+              )}
             </div>
 
             {/* 市場價格 */}
@@ -1986,6 +2427,103 @@ const FarmGame = () => {
                 {currentNPC.dialogue[Math.floor(Math.random() * currentNPC.dialogue.length)]}
               </p>
             </div>
+            {currentNPC.quests && currentNPC.quests.length > 0 && (
+              <div className="mb-4 space-y-3">
+                <h3 className="text-sm font-semibold text-gray-700">可進行的任務</h3>
+                {currentNPC.quests.map(quest => {
+                  const log = questLog[quest.id] || null;
+                  const status = log?.status ?? 'available';
+                  const required = quest.count ?? 0;
+                  const inventoryCount = quest.type === 'deliver' ? (inventory?.[quest.target] ?? 0) : 0;
+                  const progress = quest.type === 'deliver'
+                    ? Math.min(required, inventoryCount)
+                    : Math.min(required, log?.progress ?? 0);
+                  const canDeliver = quest.type === 'deliver' && status === 'accepted' && inventoryCount >= required;
+                  const canClaim = status === 'ready';
+
+                  let badgeClass = 'bg-yellow-100 text-yellow-700';
+                  let statusLabel = '可接取';
+                  if (status === 'accepted') {
+                    if (canDeliver) {
+                      badgeClass = 'bg-green-100 text-green-700';
+                      statusLabel = '可交付';
+                    } else {
+                      badgeClass = 'bg-blue-100 text-blue-600';
+                      statusLabel = '進行中';
+                    }
+                  } else if (status === 'ready') {
+                    badgeClass = 'bg-green-100 text-green-700';
+                    statusLabel = '可領取';
+                  } else if (status === 'completed') {
+                    badgeClass = 'bg-gray-200 text-gray-600';
+                    statusLabel = '已完成';
+                  }
+
+                  const targetLabel = getQuestTargetLabel(quest);
+
+                  return (
+                    <div key={quest.id} className="border border-gray-200 rounded-lg p-3 bg-gray-50">
+                      <div className="flex items-start justify-between gap-2">
+                        <div>
+                          <p className="text-sm font-semibold text-gray-800 leading-snug">{quest.description}</p>
+                          <p className="text-xs text-gray-600 mt-1">獎勵 ${quest.reward}</p>
+                          {required > 0 && (
+                            <p className="text-xs text-gray-500">需求：{targetLabel} x{required}</p>
+                          )}
+                          {required > 0 && (
+                            <p className="text-xs text-gray-500">
+                              {quest.type === 'deliver'
+                                ? `庫存 ${inventoryCount}/${required}`
+                                : `進度 ${progress}/${required}`}
+                            </p>
+                          )}
+                        </div>
+                        <span className={`text-[11px] px-2 py-1 rounded-full ${badgeClass}`}>{statusLabel}</span>
+                      </div>
+                      <div className="mt-2 flex justify-end gap-2">
+                        {status === 'available' && (
+                          <button
+                            onClick={() => acceptQuest(quest.id)}
+                            className="text-xs bg-blue-500 text-white px-3 py-1 rounded hover:bg-blue-600 transition-colors"
+                          >
+                            接受任務
+                          </button>
+                        )}
+                        {quest.type === 'deliver' && status === 'accepted' && (
+                          <button
+                            onClick={() => deliverQuest(quest.id)}
+                            disabled={!canDeliver}
+                            className={`text-xs px-3 py-1 rounded transition-colors ${canDeliver
+                              ? 'bg-rose-500 text-white hover:bg-rose-600'
+                              : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                            }`}
+                          >
+                            立即交付
+                          </button>
+                        )}
+                        {quest.type === 'deliver' && status === 'completed' && (
+                          <span className="text-xs text-gray-500">感謝你的幫忙！</span>
+                        )}
+                        {quest.type !== 'deliver' && canClaim && (
+                          <button
+                            onClick={() => claimQuestReward(quest.id)}
+                            className="text-xs bg-emerald-500 text-white px-3 py-1 rounded hover:bg-emerald-600 transition-colors"
+                          >
+                            領取獎勵
+                          </button>
+                        )}
+                        {quest.type !== 'deliver' && status === 'accepted' && !canClaim && (
+                          <span className="text-xs text-gray-500">努力完成目標中…</span>
+                        )}
+                        {quest.type !== 'deliver' && status === 'completed' && (
+                          <span className="text-xs text-gray-500">任務已完成！</span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
             <button onClick={() => setShowNPCDialog(false)}
                     className="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded transition-colors">
               結束對話

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed, TrendingUp, TrendingDown, Clock3, Boxes } from 'lucide-react';
 import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from './game/data/GameCatalog';
 import { GameFormatter } from './game/utils/GameFormatter';
-import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, FARM_EXPANSION_BATCH, ANIMAL_CAPACITY_STEP } from './game/engine/GameEngine';
+import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, FARM_EXPANSION_BATCH, ANIMAL_CAPACITY_STEP, BUILDING_UPGRADES } from './game/engine/GameEngine';
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
 
@@ -358,6 +358,19 @@ const FarmGame = () => {
     },
     notifier: addNotification,
   }), [stateRef, addNotification, recordQuestEvent]);
+
+  const sprinklerLevel = useMemo(
+    () => gameEngine.getBuildingLevel(buildings, 'sprinkler'),
+    [gameEngine, buildings],
+  );
+  const sprinklerCoverage = useMemo(
+    () => gameEngine.getSprinklerCoverage(buildings),
+    [gameEngine, buildings],
+  );
+  const nextSprinklerUpgrade = useMemo(() => {
+    const upgrades = BUILDING_UPGRADES.sprinkler || [];
+    return upgrades.find(entry => entry.level === sprinklerLevel + 1) || null;
+  }, [sprinklerLevel]);
 
   const acceptQuest = useCallback((questId) => {
     const quest = questDefinitions[questId];
@@ -814,8 +827,7 @@ const FarmGame = () => {
             prevAnimals.forEach(animal => {
               const animalData = ANIMALS[animal.type];
               const shelterKey = animalData.shelter;
-              const hasShelter = buildings?.[shelterKey];
-              const boost = hasShelter ? BUILDINGS[shelterKey].boost : 1;
+              const boost = gameEngine.getShelterBoost(buildings, shelterKey);
 
               const previousHunger = animal.hunger ?? 60;
               const hunger = Math.max(0, previousHunger - 30);
@@ -986,9 +998,12 @@ const FarmGame = () => {
           const stormDamaged = [];
           const blightInfected = [];
           const autoWatered = new Set();
+          const uncoveredByCoverage = new Set();
+          const sprinklerLevel = gameEngine.getBuildingLevel(buildings, 'sprinkler');
+          const sprinklerCoverage = gameEngine.getSprinklerCoverage(buildings);
+          let autoWaterCapacityUsed = 0;
           setFarm(prevFarm => {
             let changed = false;
-            const hasSprinkler = buildings?.sprinkler;
             const nextFarm = prevFarm.map(plot => {
               let updatedPlot = plot;
 
@@ -1029,11 +1044,17 @@ const FarmGame = () => {
                   updatedPlot = { ...updatedPlot, pestDays: 0 };
                 }
 
-                if (hasSprinkler && updatedPlot.crop && !updatedPlot.ready && !updatedPlot.watered) {
-                  const cropInfo = CROPS[updatedPlot.crop];
-                  updatedPlot = { ...updatedPlot, watered: true };
-                  if (cropInfo) {
-                    autoWatered.add(cropInfo.name);
+                const cropInfo = updatedPlot.crop ? CROPS[updatedPlot.crop] : null;
+
+                if (sprinklerLevel > 0 && sprinklerCoverage > 0 && updatedPlot.crop && !updatedPlot.ready && !updatedPlot.watered) {
+                  if (autoWaterCapacityUsed < sprinklerCoverage) {
+                    autoWaterCapacityUsed += 1;
+                    updatedPlot = { ...updatedPlot, watered: true };
+                    if (cropInfo) {
+                      autoWatered.add(cropInfo.name);
+                    }
+                  } else if (cropInfo) {
+                    uncoveredByCoverage.add(cropInfo.name);
                   }
                 }
               } else {
@@ -1144,6 +1165,11 @@ const FarmGame = () => {
             addNotification(`🚿 自動灑水器已為 ${names} 補足水分。`, { type: 'info' });
           }
 
+          if (uncoveredByCoverage.size > 0) {
+            const names = Array.from(uncoveredByCoverage).join('、');
+            addNotification(`🚿 ${names} 超出了現有自動灑水範圍，請考慮升級灌溉設備。`, { type: 'warning' });
+          }
+
           return 6;
         }
         return newTime;
@@ -1151,7 +1177,7 @@ const FarmGame = () => {
     }, 15000);
 
     return () => clearInterval(timer);
-  }, [season, buildings, animals, addNotification]);
+  }, [season, buildings, animals, addNotification, gameEngine]);
 
   // 天氣系統
   useEffect(() => {
@@ -1496,10 +1522,17 @@ const FarmGame = () => {
                 );
               })}
             </div>
-            {buildings?.sprinkler && (
+            {sprinklerLevel > 0 && (
               <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-700 flex items-center gap-2">
                 <Droplets className="w-3 h-3" />
-                自動灑水器會在每日清晨為尚未成熟的作物補水，並降低人工澆水所需體力。
+                <span>
+                  自動灑水器 Lv{sprinklerLevel} 覆蓋 {Math.min(sprinklerCoverage, farmSize)}/{farmSize} 格農地，
+                  {sprinklerCoverage < farmSize
+                    ? nextSprinklerUpgrade
+                      ? `升級可擴充至 ${nextSprinklerUpgrade.coverage} 格。`
+                      : '已達覆蓋上限，記得安排人工澆水。'
+                    : '所有作物都會在清晨自動補水。'}
+                </span>
               </div>
             )}
 
@@ -1530,7 +1563,11 @@ const FarmGame = () => {
                       <span className="text-2xl">{entry.meta.emoji}</span>
                       <span className="text-sm font-semibold">
                         {entry.meta.name}
-                        {entry.key === 'greenhouse' && entry.count ? ` x${entry.count}` : ''}
+                        {entry.key === 'greenhouse'
+                          ? entry.count ? ` x${entry.count}` : ''
+                          : typeof entry.value === 'number'
+                            ? ` Lv${entry.value}`
+                            : ''}
                       </span>
                     </div>
                   ))}
@@ -1557,7 +1594,8 @@ const FarmGame = () => {
                 <div className="grid grid-cols-4 gap-4">
                   {animals.map((animal) => {
                     const animalData = ANIMALS[animal.type];
-                    const hasBuilding = buildings[animalData.shelter];
+                    const shelterLevel = gameEngine.getBuildingLevel(buildings, animalData.shelter);
+                    const hasBuilding = shelterLevel > 0;
                     const hunger = animal.hunger ?? 50;
                     const isHungry = hunger <= 30;
                     const isSick = Boolean(animal.sick);
@@ -1574,6 +1612,9 @@ const FarmGame = () => {
                         {hasBuilding && (
                           <div className="absolute top-1 right-1 text-xs">
                             {BUILDINGS[animalData.shelter].emoji}
+                            {shelterLevel > 1 && (
+                              <span className="ml-1 text-[10px] font-semibold text-green-700">Lv{shelterLevel}</span>
+                            )}
                           </div>
                         )}
                         {isSick && (
@@ -2338,61 +2379,98 @@ const FarmGame = () => {
       {showBuildingShop && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 max-w-3xl w-full mx-4 max-h-96 overflow-y-auto">
-            <h2 className="text-xl font-bold mb-4">建築商店</h2>
-            <div className="grid grid-cols-2 gap-4">
-              {Object.entries(BUILDINGS).map(([key, building]) => {
-                const rawValue = buildings?.[key];
-                const isGreenhouse = key === 'greenhouse';
-                const greenhouseCount = isGreenhouse
-                  ? (typeof rawValue === 'number'
-                    ? rawValue
-                    : (rawValue && Array.isArray(farm) ? farm.filter(plot => plot.greenhouse).length : 0))
-                  : 0;
-                const isOwned = isGreenhouse ? greenhouseCount > 0 : Boolean(rawValue);
-                const canPurchase = isGreenhouse || !isOwned;
-                const cardHighlight = isGreenhouse && greenhouseCount > 0
-                  ? 'bg-teal-50 border-teal-300'
-                  : isOwned
-                    ? 'bg-green-100 border-green-400'
-                    : 'hover:bg-gray-50';
+              <h2 className="text-xl font-bold mb-4">建築商店</h2>
+              <div className="grid grid-cols-2 gap-4">
+                {Object.entries(BUILDINGS).map(([key, building]) => {
+                  const rawValue = buildings?.[key];
+                  const isGreenhouse = key === 'greenhouse';
+                  const greenhouseCount = isGreenhouse
+                    ? (typeof rawValue === 'number'
+                      ? rawValue
+                      : (rawValue && Array.isArray(farm) ? farm.filter(plot => plot.greenhouse).length : 0))
+                    : 0;
+                  const currentLevel = isGreenhouse ? greenhouseCount : gameEngine.getBuildingLevel(buildings, key);
+                  const upgrades = BUILDING_UPGRADES[key] || [];
+                  const hasLevels = upgrades.length > 0;
+                  const nextUpgrade = hasLevels
+                    ? upgrades.find(entry => entry.level === currentLevel + 1)
+                    : null;
+                  const currentInfo = hasLevels
+                    ? upgrades.find(entry => entry.level === (currentLevel > 0 ? currentLevel : upgrades[0].level))
+                    : null;
+                  const isOwned = isGreenhouse ? greenhouseCount > 0 : currentLevel > 0;
+                  const canPurchase = isGreenhouse
+                    ? true
+                    : hasLevels
+                      ? Boolean(nextUpgrade)
+                      : !isOwned;
+                  const cardHighlight = isGreenhouse && greenhouseCount > 0
+                    ? 'bg-teal-50 border-teal-300'
+                    : isOwned
+                      ? (hasLevels && !nextUpgrade ? 'bg-amber-50 border-amber-300' : 'bg-green-100 border-green-400')
+                      : 'hover:bg-gray-50';
+                  const priceLabel = isGreenhouse
+                    ? `$${building.price}`
+                    : hasLevels
+                      ? nextUpgrade
+                        ? `$${nextUpgrade.cost}`
+                        : '已滿級'
+                      : isOwned
+                        ? '已擁有'
+                        : `$${building.price}`;
+                  const actionLabel = isGreenhouse
+                    ? (greenhouseCount > 0 ? '再購一格' : '建造')
+                    : hasLevels
+                      ? nextUpgrade
+                        ? (currentLevel > 0 ? `升級至 Lv${nextUpgrade.level}` : '建造')
+                        : `Lv${currentLevel}`
+                      : (isOwned ? '已建造' : '建造');
 
-                return (
-                  <div key={key}
-                       className={`border rounded-lg p-4 transition-colors ${cardHighlight} ${canPurchase ? 'cursor-pointer' : 'cursor-not-allowed opacity-80'}`}
-                       onClick={() => canPurchase && buyBuilding(key)}>
-                    <div className="text-center">
-                      <div className="text-3xl mb-2">{building.emoji}</div>
-                      <div className="font-semibold">{building.name}</div>
-                      <div className={`font-bold ${isOwned && !isGreenhouse ? 'text-green-600' : 'text-green-600'}`}>
-                        {isGreenhouse
-                          ? `$${building.price}`
-                          : isOwned
-                            ? '已擁有'
-                            : `$${building.price}`}
-                      </div>
-                      <div className="text-xs text-gray-600 mt-2 space-y-1">
-                        <p>{building.description}</p>
-                        {isGreenhouse && (
-                          <p className="text-teal-600">
-                            {greenhouseCount > 0
-                              ? `目前共有 ${greenhouseCount} 格溫室土地，可再購買擴充。`
-                              : '每次購買可讓一格農地升級為溫室。'}
-                          </p>
+                  return (
+                    <div key={key}
+                         className={`border rounded-lg p-4 transition-colors ${cardHighlight} ${canPurchase ? 'cursor-pointer' : 'cursor-not-allowed opacity-80'}`}
+                         onClick={() => canPurchase && buyBuilding(key)}>
+                      <div className="text-center space-y-2">
+                        <div className="text-3xl mb-2">{building.emoji}</div>
+                        <div className="font-semibold">
+                          {building.name}
+                          {hasLevels && currentLevel > 0 && key !== 'greenhouse' && (
+                            <span className="ml-1 text-sm text-green-600">Lv{currentLevel}</span>
+                          )}
+                        </div>
+                        <div className={`font-bold ${canPurchase ? 'text-green-600' : 'text-gray-500'}`}>{priceLabel}</div>
+                        <div className="text-xs text-gray-500">{actionLabel}</div>
+                        <div className="text-xs text-gray-600 mt-2 space-y-1">
+                          <p>{building.description}</p>
+                          {isGreenhouse && (
+                            <p className="text-teal-600">
+                              {greenhouseCount > 0
+                                ? `目前共有 ${greenhouseCount} 格溫室土地，可再購買擴充。`
+                                : '每次購買可讓一格農地升級為溫室。'}
+                            </p>
+                          )}
+                          {hasLevels && currentInfo && (
+                            <p className={currentLevel > 0 ? 'text-green-600' : 'text-blue-600'}>
+                              {currentLevel > 0 ? `目前 Lv${currentLevel}：` : '等級預覽：'}{currentInfo.description}
+                            </p>
+                          )}
+                          {hasLevels && nextUpgrade && (
+                            <p className="text-blue-600">下一級：{nextUpgrade.description}</p>
+                          )}
+                        </div>
+                        {!hasLevels && building.boost !== 1.0 && (
+                          <div className="text-xs text-blue-600">
+                            效果加成: {Math.round(building.boost * 100)}%
+                          </div>
                         )}
                       </div>
-                      {building.boost !== 1.0 && (
-                        <div className="text-xs text-blue-600">
-                          效果加成: {Math.round(building.boost * 100)}%
-                        </div>
-                      )}
                     </div>
-                  </div>
-                );
-              })}
-            </div>
-            <button onClick={() => setShowBuildingShop(false)}
-                    className="mt-4 w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded transition-colors">
-              關閉
+                  );
+                })}
+              </div>
+              <button onClick={() => setShowBuildingShop(false)}
+                      className="mt-4 w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded transition-colors">
+                關閉
             </button>
           </div>
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,29 @@ import { NotificationCenter } from './game/engine/NotificationCenter';
 import { createInitialInventory, INVENTORY_METADATA, INVENTORY_ORDER } from './game/state/InventoryState';
 import { QuestManager } from './game/quests/QuestManager';
 
+const ANIMAL_ECOLOGY_CONFIG = {
+  dailyHungerLoss: 28,
+  hungerWarningThreshold: 35,
+  severeHungerThreshold: 12,
+  happinessDecay: 8,
+  severeHungerPenalty: 25,
+  moderateHungerPenalty: 10,
+  sicknessPenalty: 15,
+  sicknessTriggerThreshold: 25,
+  illnessDeathDays: 3,
+  illnessDeathChance: 0.35,
+  overcrowdThreshold: 0.85,
+  overcrowdPenalty: 12,
+  breeding: {
+    wellFedThreshold: 70,
+    happyThreshold: 70,
+    baseChance: 0.1,
+    happinessWeight: 0.003,
+    hungerWeight: 0.0025,
+    maxPairsPerType: 3,
+  },
+};
+
 const FarmGame = () => {
   // 基本狀態
   const [money, setMoney] = useState(500);
@@ -51,6 +74,7 @@ const FarmGame = () => {
   const [buildings, setBuildings] = useState({});
   const [tools, setTools] = useState('basic');
   const [ownedTools, setOwnedTools] = useState(() => ['basic']);
+  const [toolLevels, setToolLevels] = useState({});
 
   // UI狀態
   const [selectedSeed, setSelectedSeed] = useState(null);
@@ -117,6 +141,21 @@ const FarmGame = () => {
       ? getAnimalHousingExpansionCost(animalCapacity)
       : null
   ), [animalCapacity]);
+
+  const effectiveToolStats = useMemo(() => {
+    const baseTool = TOOLS[tools] || TOOLS.basic;
+    const level = toolLevels?.[tools] ?? 0;
+    const speedBoost = (baseTool.speedBoost || 1) + (baseTool.speedUpgrade || 0) * level;
+    const energyReduction = (baseTool.energyReduction || 0) + (baseTool.energyUpgrade || 0) * level;
+
+    return {
+      base: baseTool,
+      level,
+      displayLevel: level + 1,
+      speedBoost,
+      energyReduction,
+    };
+  }, [tools, toolLevels]);
   
   // 新功能狀態
   const [completedAchievements, setCompletedAchievements] = useState(new Set());
@@ -157,6 +196,7 @@ const FarmGame = () => {
     buildings,
     tools,
     ownedTools,
+    toolLevels,
     completedAchievements,
     dailyStats,
     automation,
@@ -193,6 +233,7 @@ const FarmGame = () => {
       setBuildings,
       setTools,
       setOwnedTools,
+      setToolLevels,
       setFarmSupplies,
       setQuestLog,
       setCompletedAchievements,
@@ -236,6 +277,7 @@ const FarmGame = () => {
       setTools,
       setShowToolShop,
       setOwnedTools,
+      setToolLevels,
       setPendingGreenhousePlacement,
       recordQuestEvent,
     },
@@ -632,107 +674,113 @@ const FarmGame = () => {
 
             let totalIncome = 0;
             const hungryNames = [];
-            const lostAnimals = [];
+            const starvationLosses = [];
+            const illnessLosses = [];
             const newlySick = [];
             const sickAnimals = [];
-            const updatedAnimals = [];
+            const outbreakVictims = [];
+            const overcrowdAlerts = [];
             const newbornAnimals = [];
+            const breedingPools = {};
+            const capacityLimit = Math.max(animalCapacity || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY);
+
             const typeCounts = prevAnimals.reduce((counts, current) => {
               const type = current.type;
               counts[type] = (counts[type] || 0) + 1;
               return counts;
             }, {});
 
-            prevAnimals.forEach(animal => {
+            const updatedAnimals = prevAnimals.reduce((list, animal) => {
               const animalData = ANIMALS[animal.type];
               const shelterKey = animalData.shelter;
               const boost = gameEngine.getShelterBoost(buildings, shelterKey);
 
               const previousHunger = animal.hunger ?? 60;
-              const hunger = Math.max(0, previousHunger - 30);
+              const hunger = Math.max(0, previousHunger - ANIMAL_ECOLOGY_CONFIG.dailyHungerLoss);
 
               if (hunger <= 0) {
-                lostAnimals.push(animal.name);
-                return;
+                starvationLosses.push(animal.name);
+                return list;
               }
 
-              let happiness = Math.max(0, (animal.happiness ?? animalData.happiness) - 10);
-              let canProduce = happiness > 20 && hunger > 30;
+              const baseHappiness = animal.happiness ?? animalData.happiness;
+              let happiness = Math.max(0, baseHappiness - ANIMAL_ECOLOGY_CONFIG.happinessDecay);
               let sick = Boolean(animal.sick);
+              const wasSick = Boolean(animal.sick);
+              let sicknessDays = animal.sicknessDays ?? (wasSick ? 1 : 0);
+              let canProduce = happiness > 25 && hunger > ANIMAL_ECOLOGY_CONFIG.hungerWarningThreshold;
 
-              if (hunger <= 10) {
+              if (hunger <= ANIMAL_ECOLOGY_CONFIG.severeHungerThreshold) {
                 hungryNames.push(`${animal.name}（急需餵食）`);
-                happiness = Math.max(0, happiness - 25);
+                happiness = Math.max(0, happiness - ANIMAL_ECOLOGY_CONFIG.severeHungerPenalty);
                 canProduce = false;
-              } else if (hunger <= 30) {
+              } else if (hunger <= ANIMAL_ECOLOGY_CONFIG.hungerWarningThreshold) {
                 hungryNames.push(animal.name);
-                happiness = Math.max(0, happiness - 10);
-                canProduce = happiness > 25;
+                happiness = Math.max(0, happiness - ANIMAL_ECOLOGY_CONFIG.moderateHungerPenalty);
+                canProduce = happiness > 30;
               }
 
-              if (!sick && (hunger <= 20 || happiness <= 20)) {
+              if (!sick && (hunger <= ANIMAL_ECOLOGY_CONFIG.sicknessTriggerThreshold || happiness <= ANIMAL_ECOLOGY_CONFIG.sicknessTriggerThreshold)) {
                 sick = true;
                 newlySick.push(animal.name);
               }
 
               if (sick) {
-                happiness = Math.max(0, happiness - 15);
+                sicknessDays += 1;
+                happiness = Math.max(0, happiness - ANIMAL_ECOLOGY_CONFIG.sicknessPenalty);
                 canProduce = false;
                 sickAnimals.push(animal.name);
-              }
-
-            let income = 0;
-            let productReady = Math.max(0, Math.floor(animal.productReady || 0));
-            if (canProduce) {
-              if (animalData.product && ANIMAL_PRODUCTS[animalData.product]) {
-                const productKey = animalData.product;
-                const baseUnits = 1;
-                const units = Math.max(1, Math.round(baseUnits * boost * (happiness / 100)));
-                productReady += units;
-                producedGoods[productKey] = (producedGoods[productKey] || 0) + units;
               } else {
-                income = Math.floor(animalData.income * boost * (happiness / 100));
+                sicknessDays = 0;
               }
-            }
-            totalIncome += income;
 
-            if (!animalData.product) {
-              productReady = 0;
-            }
+              if (sick && sicknessDays >= ANIMAL_ECOLOGY_CONFIG.illnessDeathDays && Math.random() < ANIMAL_ECOLOGY_CONFIG.illnessDeathChance) {
+                illnessLosses.push(animal.name);
+                return list;
+              }
 
-            if (!sick && hunger >= 75 && happiness >= 75 && newbornAnimals.length < 3) {
-              const birthChance = 0.12
-                + (happiness > 90 ? 0.05 : 0)
-                + (hunger > 90 ? 0.05 : 0);
-                if (Math.random() < birthChance) {
-                  typeCounts[animal.type] = (typeCounts[animal.type] || 0) + 1;
-                  const baseName = animalData.name;
-                  const babyIndex = typeCounts[animal.type];
-                  const babyName = `${baseName}寶寶${babyIndex}`;
-                  newbornAnimals.push({
-                    id: Date.now() + newbornAnimals.length + Math.floor(Math.random() * 1000),
-                    type: animal.type,
-                    happiness: animalData.happiness,
-                    hunger: 65,
-                    lastFed: Date.now(),
-                    sick: false,
-                    name: babyName,
-                    productReady: 0,
-                  });
+              let income = 0;
+              let productReady = Math.max(0, Math.floor(animal.productReady || 0));
+              if (canProduce) {
+                if (animalData.product && ANIMAL_PRODUCTS[animalData.product]) {
+                  const productKey = animalData.product;
+                  const baseUnits = 1;
+                  const units = Math.max(1, Math.round(baseUnits * boost * (happiness / 100)));
+                  productReady += units;
+                  producedGoods[productKey] = (producedGoods[productKey] || 0) + units;
+                } else {
+                  income = Math.floor((animalData.income || 0) * boost * (happiness / 100));
                 }
               }
+              totalIncome += income;
 
-              updatedAnimals.push({
+              if (!animalData.product) {
+                productReady = 0;
+              }
+
+              const canBreed = !sick
+                && hunger >= ANIMAL_ECOLOGY_CONFIG.breeding.wellFedThreshold
+                && happiness >= ANIMAL_ECOLOGY_CONFIG.breeding.happyThreshold;
+              if (canBreed) {
+                if (!breedingPools[animal.type]) {
+                  breedingPools[animal.type] = [];
+                }
+                breedingPools[animal.type].push({ happiness, hunger });
+              }
+
+              list.push({
                 ...animal,
                 happiness,
                 hunger,
                 sick,
+                sicknessDays,
                 productReady,
               });
-            });
+              return list;
+            }, []);
 
             let processedAnimals = updatedAnimals;
-            const outbreakVictims = [];
+
             if (processedAnimals.length > 0 && Math.random() < 0.08) {
               const healthyCandidates = processedAnimals.filter(candidate => !candidate.sick);
               if (healthyCandidates.length > 0) {
@@ -751,6 +799,7 @@ const FarmGame = () => {
                     const adjusted = {
                       ...state,
                       sick: true,
+                      sicknessDays: (state.sicknessDays ?? 0) + 1,
                       happiness: Math.max(0, baseHappiness - 20),
                       hunger: Math.max(0, baseHunger - 25),
                     };
@@ -764,6 +813,63 @@ const FarmGame = () => {
               }
             }
 
+            const occupancyRatio = capacityLimit > 0 ? processedAnimals.length / capacityLimit : 1;
+            if (occupancyRatio > ANIMAL_ECOLOGY_CONFIG.overcrowdThreshold) {
+              const overflow = Math.max(0, occupancyRatio - ANIMAL_ECOLOGY_CONFIG.overcrowdThreshold);
+              const penalty = Math.max(2, Math.ceil(ANIMAL_ECOLOGY_CONFIG.overcrowdPenalty * overflow / (1 - ANIMAL_ECOLOGY_CONFIG.overcrowdThreshold)));
+              processedAnimals = processedAnimals.map(state => {
+                const animalData = ANIMALS[state.type];
+                const baseHappiness = state.happiness ?? animalData.happiness ?? 40;
+                const reduced = Math.max(0, baseHappiness - penalty);
+                let nextState = { ...state, happiness: reduced };
+                if (!nextState.sick && reduced <= ANIMAL_ECOLOGY_CONFIG.sicknessTriggerThreshold) {
+                  nextState = { ...nextState, sick: true, sicknessDays: (nextState.sicknessDays ?? 0) + 1 };
+                  newlySick.push(nextState.name);
+                  sickAnimals.push(nextState.name);
+                }
+                return nextState;
+              });
+              overcrowdAlerts.push('overcrowded');
+            }
+
+            let availableSlots = Math.max(0, capacityLimit - processedAnimals.length);
+            Object.entries(breedingPools).forEach(([type, candidates]) => {
+              if (availableSlots <= 0) {
+                return;
+              }
+              if (candidates.length < 2) {
+                return;
+              }
+
+              const averageHappiness = candidates.reduce((sum, entry) => sum + entry.happiness, 0) / candidates.length;
+              const averageHunger = candidates.reduce((sum, entry) => sum + entry.hunger, 0) / candidates.length;
+              const pairCount = Math.min(Math.floor(candidates.length / 2), ANIMAL_ECOLOGY_CONFIG.breeding.maxPairsPerType);
+              const chance = ANIMAL_ECOLOGY_CONFIG.breeding.baseChance
+                + Math.max(0, (averageHappiness - ANIMAL_ECOLOGY_CONFIG.breeding.happyThreshold) * ANIMAL_ECOLOGY_CONFIG.breeding.happinessWeight)
+                + Math.max(0, (averageHunger - ANIMAL_ECOLOGY_CONFIG.breeding.wellFedThreshold) * ANIMAL_ECOLOGY_CONFIG.breeding.hungerWeight);
+
+              for (let attempt = 0; attempt < pairCount && availableSlots > 0; attempt += 1) {
+                if (Math.random() < chance) {
+                  const data = ANIMALS[type];
+                  typeCounts[type] = (typeCounts[type] || 0) + 1;
+                  const babyIndex = typeCounts[type];
+                  const babyName = `${data.name}寶寶${babyIndex}`;
+                  newbornAnimals.push({
+                    id: Date.now() + newbornAnimals.length + Math.floor(Math.random() * 1000),
+                    type,
+                    happiness: data.happiness,
+                    hunger: 68,
+                    lastFed: Date.now(),
+                    sick: false,
+                    sicknessDays: 0,
+                    name: babyName,
+                    productReady: 0,
+                  });
+                  availableSlots -= 1;
+                }
+              }
+            });
+
             if (totalIncome > 0) {
               setMoney(prevMoney => prevMoney + totalIncome);
               addNotification(`🐾 動物們帶來了 $${totalIncome} 的收入！`, { type: 'success' });
@@ -774,9 +880,14 @@ const FarmGame = () => {
               addNotification(`🍽️ ${names} 肚子餓了，記得餵食！`, { type: 'warning' });
             }
 
-            if (lostAnimals.length > 0) {
-              const names = Array.from(new Set(lostAnimals)).join('、');
+            if (starvationLosses.length > 0) {
+              const names = Array.from(new Set(starvationLosses)).join('、');
               addNotification(`💀 ${names} 因為長期挨餓離開了農場……`, { type: 'error' });
+            }
+
+            if (illnessLosses.length > 0) {
+              const names = Array.from(new Set(illnessLosses)).join('、');
+              addNotification(`☠️ ${names} 因病過世，務必照顧好其他動物的健康！`, { type: 'error' });
             }
 
             if (newlySick.length > 0) {
@@ -792,6 +903,10 @@ const FarmGame = () => {
             const ongoingSick = Array.from(new Set(sickAnimals.filter(name => !newlySick.includes(name))));
             if (ongoingSick.length > 0) {
               addNotification(`💊 ${ongoingSick.join('、')} 仍在療養中，記得使用營養劑。`, { type: 'warning' });
+            }
+
+            if (overcrowdAlerts.length > 0) {
+              addNotification('🐏 動物棲位過於擁擠，建議擴建欄舍或調整飼養量！', { type: 'warning' });
             }
 
             if (newbornAnimals.length > 0) {
@@ -996,7 +1111,7 @@ const FarmGame = () => {
     }, 15000);
 
     return () => clearInterval(timer);
-  }, [season, buildings, animals, addNotification, gameEngine]);
+  }, [season, buildings, animals, addNotification, gameEngine, animalCapacity]);
 
   // 天氣系統
   useEffect(() => {
@@ -1025,7 +1140,7 @@ const FarmGame = () => {
 
           let weatherMultiplier = plot.greenhouse ? 1.2 : (cropData.weatherBonus[weather] || 1);
           const seasonMultiplier = plot.greenhouse ? 1 : (cropData.seasonBonus?.[season] ?? 1);
-          const toolMultiplier = TOOLS[tools].speedBoost;
+          const toolMultiplier = effectiveToolStats.speedBoost;
           const fertilizerBoost = plot.fertilized ? 1.25 : 1;
 
           const adjustedGrowTime = (cropData.growTime * 60000)
@@ -1041,7 +1156,7 @@ const FarmGame = () => {
     }, 5000);
 
     return () => clearInterval(growTimer);
-  }, [weather, tools, season, addNotification]);
+  }, [weather, season, addNotification, effectiveToolStats]);
 
   // 升級系統
   useEffect(() => {
@@ -1197,7 +1312,7 @@ const FarmGame = () => {
           </div>
           <div className="flex items-center space-x-1">
             <Hammer className="w-4 h-4 text-gray-400" />
-            <span className="text-sm">{TOOLS[tools].name}</span>
+            <span className="text-sm">{effectiveToolStats.base.name} Lv.{effectiveToolStats.displayLevel}</span>
           </div>
         </div>
         
@@ -2128,7 +2243,7 @@ const FarmGame = () => {
                 <h3 className="font-semibold text-lg text-blue-600">🏠 建築與工具</h3>
                 <ul className="list-disc pl-5 space-y-1 mt-2">
                   <li>建築能提升產量或帶來特殊效果，例如溫室免受天氣影響、筒倉賣價 +10%。</li>
-                  <li>工具分四個等級，等級越高越省體力、作物長得越快。</li>
+                  <li>工具共有多階段升級，每提升一級作物成長加快 15%，魔法工具更能無限強化。</li>
                 </ul>
               </section>
               <section>
@@ -2395,6 +2510,13 @@ const FarmGame = () => {
               {Object.entries(TOOLS).map(([key, tool]) => {
                 const isActive = tools === key;
                 const isOwned = ownedTools.includes(key);
+                const currentLevel = toolLevels?.[key] ?? 0;
+                const ownedLevel = isOwned ? currentLevel : 0;
+                const displayLevel = ownedLevel + 1;
+                const displaySpeed = (tool.speedBoost || 1) + (tool.speedUpgrade || 0) * ownedLevel;
+                const displayEnergy = (tool.energyReduction || 0) + (tool.energyUpgrade || 0) * ownedLevel;
+                const nextUpgradeCost = tool.upgradeCost;
+                const canUpgrade = isOwned && Boolean(nextUpgradeCost);
                 const cardClass = isActive
                   ? 'bg-green-100 border-green-400'
                   : isOwned
@@ -2406,24 +2528,31 @@ const FarmGame = () => {
                     ? '已購買'
                     : tool.price === 0
                       ? '免費'
-                      : `${tool.price}`;
+                      : `$${tool.price}`;
 
                 return (
-                  <div key={key}
-                       className={`border rounded-lg p-4 cursor-pointer transition-colors ${cardClass}`}
-                       onClick={() => buyTool(key)}>
-                    <div className="flex justify-between items-center">
+                  <div
+                    key={key}
+                    className={`border rounded-lg p-4 cursor-pointer transition-colors ${cardClass}`}
+                    onClick={() => buyTool(key)}
+                  >
+                    <div className="flex justify-between items-start gap-3">
                       <div>
-                        <div className="font-semibold">{tool.name}</div>
+                        <div className="font-semibold">{tool.name} {isOwned && <span className="text-xs text-gray-500">Lv.{displayLevel}</span>}</div>
                         <div className="text-sm text-gray-600">
-                          節省體力: {tool.energyReduction}
+                          節省體力: {Math.round(displayEnergy)}
                         </div>
                         <div className="text-sm text-gray-600">
-                          速度加成: {Math.round(tool.speedBoost * 100)}%
+                          速度加成: {Math.round(displaySpeed * 100)}%
                         </div>
+                        {canUpgrade && (
+                          <div className="mt-2 text-xs text-amber-600">
+                            下一級可達 {Math.round(((tool.speedBoost || 1) + (tool.speedUpgrade || 0) * (ownedLevel + 1)) * 100)}%／節省 {Math.round((tool.energyReduction || 0) + (tool.energyUpgrade || 0) * (ownedLevel + 1))}
+                          </div>
+                        )}
                       </div>
                       <div className="text-right">
-                        <div className={`font-bold ${isActive ? 'text-green-600' : isOwned ? 'text-blue-600' : 'text-blue-600'}`}>
+                        <div className={`font-bold ${isActive ? 'text-green-600' : 'text-blue-600'}`}>
                           {priceLabel}
                         </div>
                         {isOwned && !isActive && (
@@ -2431,6 +2560,20 @@ const FarmGame = () => {
                         )}
                       </div>
                     </div>
+                    {canUpgrade && (
+                      <div className="mt-3 flex items-center justify-between gap-3">
+                        <span className="text-xs text-gray-500">目前等級 Lv.{displayLevel}</span>
+                        <button
+                          className="text-xs bg-purple-100 text-purple-700 border border-purple-300 rounded px-2 py-1 hover:bg-purple-200 transition-colors"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            buyTool(key, { upgrade: true });
+                          }}
+                        >
+                          升級 ${nextUpgradeCost}
+                        </button>
+                      </div>
+                    )}
                   </div>
                 );
               })}
@@ -2666,7 +2809,7 @@ const FarmGame = () => {
               </div>
               <div className="flex justify-between">
                 <span>當前工具:</span>
-                <span className="font-bold">{TOOLS[tools].name}</span>
+                <span className="font-bold">{effectiveToolStats.base.name} Lv.{effectiveToolStats.displayLevel}</span>
               </div>
             </div>
             <div className="mt-4 pt-4 border-t">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,9 +6,28 @@ import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_F
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
 
+const CROP_METADATA = Object.fromEntries(
+  Object.entries(CROPS).map(([key, crop]) => [key, { name: crop.name, emoji: crop.emoji, type: 'crop', cropKey: key }])
+);
+
+const SEED_METADATA = Object.fromEntries(
+  Object.entries(CROPS).map(([key, crop]) => [
+    `seed_${key}`,
+    { name: `${crop.name}種子`, emoji: crop.emoji, type: 'seed', cropKey: key },
+  ])
+);
+
+const PRODUCT_METADATA = Object.fromEntries(
+  Object.entries(ANIMAL_PRODUCTS).map(([key, product]) => [
+    key,
+    { name: product.name, emoji: product.emoji, type: 'product', animal: product.animal },
+  ])
+);
+
 const INVENTORY_METADATA = {
-  ...Object.fromEntries(Object.entries(CROPS).map(([key, crop]) => [key, { name: crop.name, emoji: crop.emoji, type: 'crop' }])),
-  ...Object.fromEntries(Object.entries(ANIMAL_PRODUCTS).map(([key, product]) => [key, { name: product.name, emoji: product.emoji, type: 'product' }])),
+  ...CROP_METADATA,
+  ...PRODUCT_METADATA,
+  ...SEED_METADATA,
 };
 
 const INVENTORY_ORDER = Object.keys(INVENTORY_METADATA);
@@ -62,6 +81,7 @@ const FarmGame = () => {
   const [animalCapacity, setAnimalCapacity] = useState(BASE_ANIMAL_CAPACITY);
   const [buildings, setBuildings] = useState({});
   const [tools, setTools] = useState('basic');
+  const [ownedTools, setOwnedTools] = useState(() => ['basic']);
 
   // UI狀態
   const [selectedSeed, setSelectedSeed] = useState(null);
@@ -180,6 +200,7 @@ const FarmGame = () => {
     animalCapacity,
     buildings,
     tools,
+    ownedTools,
     completedAchievements,
     dailyStats,
     automation,
@@ -214,6 +235,7 @@ const FarmGame = () => {
       setAnimalCapacity,
       setBuildings,
       setTools,
+      setOwnedTools,
       setFarmSupplies,
       setQuestLog,
       setCompletedAchievements,
@@ -330,6 +352,7 @@ const FarmGame = () => {
       setShowBuildingShop,
       setTools,
       setShowToolShop,
+      setOwnedTools,
       setPendingGreenhousePlacement,
       recordQuestEvent,
     },
@@ -1156,10 +1179,12 @@ const FarmGame = () => {
           const cropData = CROPS[plot.crop];
 
           let weatherMultiplier = plot.greenhouse ? 1.2 : (cropData.weatherBonus[weather] || 1);
+          const seasonMultiplier = plot.greenhouse ? 1 : (cropData.seasonBonus?.[season] ?? 1);
           const toolMultiplier = TOOLS[tools].speedBoost;
           const fertilizerBoost = plot.fertilized ? 1.25 : 1;
 
-          const adjustedGrowTime = (cropData.growTime * 60000) / (weatherMultiplier * toolMultiplier * fertilizerBoost);
+          const adjustedGrowTime = (cropData.growTime * 60000)
+            / (weatherMultiplier * toolMultiplier * fertilizerBoost * seasonMultiplier);
 
           if (now - plot.plantTime >= adjustedGrowTime && !plot.ready) {
             addNotification(`${cropData.emoji} ${cropData.name} 成熟了！`, { type: 'success' });
@@ -1171,7 +1196,7 @@ const FarmGame = () => {
     }, 5000);
 
     return () => clearInterval(growTimer);
-  }, [weather, tools, addNotification]);
+  }, [weather, tools, season, addNotification]);
 
   // 升級系統
   useEffect(() => {
@@ -1182,8 +1207,12 @@ const FarmGame = () => {
     }
   }, [experience, level, addNotification]);
 
-  const buySeed = useCallback((seedType) => {
-    gameEngine.buySeed(seedType);
+  const prepareSeed = useCallback((seedType) => {
+    gameEngine.prepareSeed(seedType);
+  }, [gameEngine]);
+
+  const purchaseSeeds = useCallback((seedType, quantity) => {
+    gameEngine.purchaseSeeds(seedType, quantity);
   }, [gameEngine]);
 
   const plantSeed = useCallback((plotId) => {
@@ -1228,6 +1257,10 @@ const FarmGame = () => {
 
   const buyTool = useCallback((toolType) => {
     gameEngine.buyTool(toolType);
+  }, [gameEngine]);
+
+  const slaughterAnimal = useCallback((animalId) => {
+    gameEngine.slaughterAnimal(animalId);
   }, [gameEngine]);
 
   const feedAnimal = useCallback((animalId) => {
@@ -1606,6 +1639,14 @@ const FarmGame = () => {
                               <div className="text-xs text-red-500">身體不適，產出暫停中。</div>
                             </div>
                           )}
+                          {animalData.butcher && (
+                            <button
+                              onClick={() => slaughterAnimal(animal.id)}
+                              className="w-full text-xs font-semibold py-1 rounded transition-colors bg-red-200 hover:bg-red-300 text-red-700 mt-2"
+                            >
+                              屠宰換取 {ANIMAL_PRODUCTS[animalData.butcher.product]?.name || '肉品'}
+                            </button>
+                          )}
                         </div>
                       </div>
                     );
@@ -1934,7 +1975,7 @@ const FarmGame = () => {
                     <Boxes className="w-4 h-4 text-amber-600" />
                     庫存
                   </h3>
-                  <p className="text-xs text-gray-500 mt-1">動物產品與作物收成都集中在這裡管理。</p>
+                  <p className="text-xs text-gray-500 mt-1">作物、畜產品與囤積的種子都會統一列在這裡。</p>
                 </div>
                 <div className="text-right text-xs">
                   <div className="text-gray-500">共 {inventoryInsights.totalCount} 件</div>
@@ -1965,6 +2006,12 @@ const FarmGame = () => {
                   {inventoryInsights.items.map(item => {
                     const halfQuantity = Math.floor(item.count / 2);
                     const shareWidth = item.share > 0 ? Math.min(100, Math.max(6, item.share)) : 0;
+                    const typeLabel = item.type === 'seed'
+                      ? '種子'
+                      : item.type === 'product'
+                        ? '畜產品'
+                        : '作物';
+                    const valueLabel = item.type === 'seed' ? '估值' : '單價';
 
                     return (
                       <div key={item.key} className="rounded-lg border border-amber-200 bg-amber-50/80 p-3">
@@ -1974,7 +2021,7 @@ const FarmGame = () => {
                             <div>
                               <div className="font-semibold text-sm text-amber-900">{item.name}</div>
                               <div className="text-xs text-amber-700">
-                                {item.type === 'product' ? '畜產品' : '作物'} · 單價 ${item.unitValue}
+                                {typeLabel} · {valueLabel} ${item.unitValue}
                               </div>
                             </div>
                           </div>
@@ -2072,6 +2119,12 @@ const FarmGame = () => {
                     <div>{CROPS[selectedSeed].name}</div>
                     <div className="text-sm text-gray-600">
                       成長時間: {CROPS[selectedSeed].growTime}分鐘
+                    </div>
+                    <div className="text-sm text-gray-600">
+                      倉庫種子: {inventory[`seed_${selectedSeed}`] || 0} 包
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      無庫存時植入需花費 ${marketPrices[selectedSeed] || CROPS[selectedSeed].price}
                     </div>
                   </div>
                 </div>
@@ -2182,25 +2235,61 @@ const FarmGame = () => {
           <div className="bg-white rounded-lg p-6 max-w-2xl w-full mx-4 max-h-96 overflow-y-auto">
             <h2 className="text-xl font-bold mb-4">種子商店</h2>
             <div className="grid grid-cols-3 gap-4">
-              {Object.entries(CROPS).map(([key, crop]) => (
-                <div key={key} 
-                     className="border rounded-lg p-4 cursor-pointer hover:bg-gray-50 transition-colors"
-                     onClick={() => buySeed(key)}>
-                  <div className="text-center">
-                    <div className="text-3xl mb-2">{crop.emoji}</div>
-                    <div className="font-semibold">{crop.name}</div>
-                    <div className="text-green-600 font-bold">
-                      ${marketPrices[key] || crop.price}
+              {Object.entries(CROPS).map(([key, crop]) => {
+                const price = marketPrices[key] || crop.price;
+                const seedKey = `seed_${key}`;
+                const storedSeeds = inventory[seedKey] || 0;
+                const seasonEntries = Object.entries(crop.seasonBonus || {});
+                const favorableSeasons = seasonEntries
+                  .filter(([, value]) => value > 1.05)
+                  .map(([seasonKey]) => GameFormatter.seasonName(seasonKey));
+                const riskySeasons = seasonEntries
+                  .filter(([, value]) => value < 0.9)
+                  .map(([seasonKey]) => GameFormatter.seasonName(seasonKey));
+
+                return (
+                  <div key={key}
+                       className="border rounded-lg p-4 bg-white/90 shadow-sm flex flex-col gap-3">
+                    <div className="text-center space-y-1">
+                      <div className="text-3xl">{crop.emoji}</div>
+                      <div className="font-semibold">{crop.name}</div>
+                      <div className="text-green-600 font-bold">${price}</div>
+                      <div className="text-xs text-gray-500">成長: {crop.growTime}分鐘</div>
+                      <div className="text-xs text-blue-600">基礎售價: ${crop.sellPrice}</div>
+                      <div className="text-xs text-amber-600">種子庫存: {storedSeeds} 包</div>
+                      {favorableSeasons.length > 0 && (
+                        <div className="text-[11px] text-emerald-600">適合季節：{favorableSeasons.join('、')}</div>
+                      )}
+                      {riskySeasons.length > 0 && (
+                        <div className="text-[11px] text-rose-500">避免季節：{riskySeasons.join('、')}</div>
+                      )}
                     </div>
-                    <div className="text-xs text-gray-500">
-                      成長: {crop.growTime}分鐘
-                    </div>
-                    <div className="text-xs text-blue-600">
-                      基礎售價: ${crop.sellPrice}
+                    <div className="space-y-2">
+                      <button
+                        onClick={() => {
+                          prepareSeed(key);
+                          setShowShop(false);
+                        }}
+                        className="w-full text-sm bg-green-500 hover:bg-green-600 text-white py-1.5 rounded transition-colors"
+                      >
+                        準備種植
+                      </button>
+                      <div className="text-[11px] text-gray-500 text-center">大量進貨可趁特價</div>
+                      <div className="flex gap-2">
+                        {[1, 5, 10].map(amount => (
+                          <button
+                            key={amount}
+                            onClick={() => purchaseSeeds(key, amount)}
+                            className="flex-1 text-xs border border-green-200 hover:border-green-400 text-green-700 rounded py-1 transition-colors"
+                          >
+                            買 {amount}
+                          </button>
+                        ))}
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
             <button onClick={() => setShowShop(false)}
                     className="mt-4 w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded transition-colors">
@@ -2315,32 +2404,48 @@ const FarmGame = () => {
           <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
             <h2 className="text-xl font-bold mb-4">工具商店</h2>
             <div className="space-y-4">
-              {Object.entries(TOOLS).map(([key, tool]) => (
-                <div key={key} 
-                     className={`border rounded-lg p-4 cursor-pointer transition-colors ${
-                       tools === key 
-                         ? 'bg-green-100 border-green-400' 
-                         : 'hover:bg-gray-50'
-                     }`}
-                     onClick={() => buyTool(key)}>
-                  <div className="flex justify-between items-center">
-                    <div>
-                      <div className="font-semibold">{tool.name}</div>
-                      <div className="text-sm text-gray-600">
-                        節省體力: {tool.energyReduction}
+              {Object.entries(TOOLS).map(([key, tool]) => {
+                const isActive = tools === key;
+                const isOwned = ownedTools.includes(key);
+                const cardClass = isActive
+                  ? 'bg-green-100 border-green-400'
+                  : isOwned
+                    ? 'border-blue-300 bg-blue-50/60 hover:bg-blue-100'
+                    : 'hover:bg-gray-50';
+                const priceLabel = isActive
+                  ? '已裝備'
+                  : isOwned
+                    ? '已購買'
+                    : tool.price === 0
+                      ? '免費'
+                      : `${tool.price}`;
+
+                return (
+                  <div key={key}
+                       className={`border rounded-lg p-4 cursor-pointer transition-colors ${cardClass}`}
+                       onClick={() => buyTool(key)}>
+                    <div className="flex justify-between items-center">
+                      <div>
+                        <div className="font-semibold">{tool.name}</div>
+                        <div className="text-sm text-gray-600">
+                          節省體力: {tool.energyReduction}
+                        </div>
+                        <div className="text-sm text-gray-600">
+                          速度加成: {Math.round(tool.speedBoost * 100)}%
+                        </div>
                       </div>
-                      <div className="text-sm text-gray-600">
-                        速度加成: {Math.round(tool.speedBoost * 100)}%
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <div className={`font-bold ${tools === key ? 'text-green-600' : 'text-blue-600'}`}>
-                        {tools === key ? '已擁有' : tool.price === 0 ? '免費' : `${tool.price}`}
+                      <div className="text-right">
+                        <div className={`font-bold ${isActive ? 'text-green-600' : isOwned ? 'text-blue-600' : 'text-blue-600'}`}>
+                          {priceLabel}
+                        </div>
+                        {isOwned && !isActive && (
+                          <div className="text-[11px] text-blue-500">點擊切換</div>
+                        )}
                       </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
             <button onClick={() => setShowToolShop(false)}
                     className="mt-4 w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded transition-colors">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,42 +5,8 @@ import { GameFormatter } from './game/utils/GameFormatter';
 import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, FARM_EXPANSION_BATCH, ANIMAL_CAPACITY_STEP, BUILDING_UPGRADES } from './game/engine/GameEngine';
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
-
-const CROP_METADATA = Object.fromEntries(
-  Object.entries(CROPS).map(([key, crop]) => [key, { name: crop.name, emoji: crop.emoji, type: 'crop', cropKey: key }])
-);
-
-const SEED_METADATA = Object.fromEntries(
-  Object.entries(CROPS).map(([key, crop]) => [
-    `seed_${key}`,
-    { name: `${crop.name}種子`, emoji: crop.emoji, type: 'seed', cropKey: key },
-  ])
-);
-
-const PRODUCT_METADATA = Object.fromEntries(
-  Object.entries(ANIMAL_PRODUCTS).map(([key, product]) => [
-    key,
-    { name: product.name, emoji: product.emoji, type: 'product', animal: product.animal },
-  ])
-);
-
-const INVENTORY_METADATA = {
-  ...CROP_METADATA,
-  ...PRODUCT_METADATA,
-  ...SEED_METADATA,
-};
-
-const INVENTORY_ORDER = Object.keys(INVENTORY_METADATA);
-
-const createInitialInventory = () => {
-  const base = {};
-  INVENTORY_ORDER.forEach(key => {
-    base[key] = 0;
-  });
-  return base;
-};
-
-const DYNAMIC_QUEST_SLOTS = 3;
+import { createInitialInventory, INVENTORY_METADATA, INVENTORY_ORDER } from './game/state/InventoryState';
+import { QuestManager } from './game/quests/QuestManager';
 
 const FarmGame = () => {
   // 基本狀態
@@ -107,174 +73,7 @@ const FarmGame = () => {
   const [marketListSort, setMarketListSort] = useState('price');
   const [inventorySortMode, setInventorySortMode] = useState('value');
 
-  const questDefinitions = useMemo(() => {
-    const map = {};
-    NPCS.forEach(npc => {
-      (npc.quests || []).forEach(quest => {
-        if (quest?.id) {
-          map[quest.id] = { ...quest, npcName: npc.name };
-        }
-      });
-    });
-
-    Object.entries(dynamicQuests || {}).forEach(([questId, quest]) => {
-      if (questId && quest) {
-        map[questId] = quest;
-      }
-    });
-
-    return map;
-  }, [dynamicQuests]);
-
-  const getQuestTargetLabel = useCallback((quest) => {
-    if (!quest?.target) {
-      return '目標';
-    }
-
-    if (CROPS[quest.target]) {
-      const crop = CROPS[quest.target];
-      return `${crop.emoji} ${crop.name}`;
-    }
-
-    if (ANIMAL_PRODUCTS[quest.target]) {
-      const product = ANIMAL_PRODUCTS[quest.target];
-      return `${product.emoji} ${product.name}`;
-    }
-
-    if (FARM_SUPPLIES[quest.target]) {
-      const supply = FARM_SUPPLIES[quest.target];
-      return `${supply.emoji} ${supply.name}`;
-    }
-
-    return quest.target;
-  }, []);
-
-  const refreshDynamicQuests = useCallback((currentDay) => {
-    const existingDynamic = stateRef.current.dynamicQuests || {};
-    const existingLog = stateRef.current.questLog || {};
-
-    const preserved = {};
-    Object.entries(existingDynamic).forEach(([id, quest]) => {
-      const status = existingLog?.[id]?.status;
-      if (status === 'accepted' || status === 'ready') {
-        preserved[id] = quest;
-      }
-    });
-
-    const questGivers = ['商會佈告欄', '旅行商人', '鄰村里長', '合作社代表', '冒險者公會'];
-    const deliverTargets = [...Object.keys(CROPS), ...Object.keys(ANIMAL_PRODUCTS)];
-    const harvestTargets = Object.keys(CROPS);
-    const sellTargets = Object.keys(CROPS);
-
-    const randomBetween = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
-    const pickOne = (list) => list[Math.floor(Math.random() * list.length)];
-
-    const usedIds = new Set(Object.keys(preserved));
-    const createQuestId = (slot) => {
-      let attempt = 0;
-      let id;
-      do {
-        id = `daily_${currentDay}_${slot}_${Math.random().toString(36).slice(2, 6)}`;
-        attempt += 1;
-      } while (usedIds.has(id) && attempt < 5);
-      usedIds.add(id);
-      return id;
-    };
-
-    const buildQuest = (slot) => {
-      const giver = pickOne(questGivers);
-      const questTypes = ['deliver', 'harvest', 'sell', 'pestClear'];
-      const type = pickOne(questTypes);
-      const questId = createQuestId(slot);
-
-      if (type === 'deliver' && deliverTargets.length > 0) {
-        const target = pickOne(deliverTargets);
-        const product = ANIMAL_PRODUCTS[target];
-        const crop = CROPS[target];
-        const isProduct = Boolean(product);
-        const label = isProduct
-          ? `${product.emoji} ${product.name}`
-          : `${crop.emoji} ${crop.name}`;
-        const basePrice = isProduct ? product.basePrice : crop.sellPrice;
-        const count = isProduct ? randomBetween(4, 12) : randomBetween(18, 45);
-        const reward = Math.max(150, Math.floor(basePrice * count * (isProduct ? 1.9 : 1.5)));
-        return {
-          id: questId,
-          type: 'deliver',
-          target,
-          count,
-          reward,
-          description: `${giver} 需要 ${count} 份${label}，協助供貨即可獲得酬勞。`,
-          npcName: giver,
-        };
-      }
-
-      if (type === 'harvest' && harvestTargets.length > 0) {
-        const target = pickOne(harvestTargets);
-        const crop = CROPS[target];
-        const count = randomBetween(10, 28);
-        const reward = Math.max(160, Math.floor(crop.sellPrice * count * (1.4 + Math.random() * 0.5)));
-        return {
-          id: questId,
-          type: 'harvest',
-          target,
-          count,
-          reward,
-          description: `${giver} 正準備市集，收成 ${count} 份${crop.emoji} ${crop.name} 就能領取獎金。`,
-          npcName: giver,
-        };
-      }
-
-      if (type === 'sell' && sellTargets.length > 0) {
-        const target = pickOne(sellTargets);
-        const crop = CROPS[target];
-        const count = randomBetween(15, 35);
-        const reward = Math.max(200, Math.floor(crop.sellPrice * count * (1.55 + Math.random() * 0.45)));
-        return {
-          id: questId,
-          type: 'sell',
-          target,
-          count,
-          reward,
-          description: `${giver} 想炒熱 ${crop.emoji} ${crop.name} 的行情，賣出 ${count} 份即可分紅。`,
-          npcName: giver,
-        };
-      }
-
-      const pestCount = randomBetween(3, 6);
-      const reward = randomBetween(180, 320);
-      return {
-        id: questId,
-        type: 'pestClear',
-        count: pestCount,
-        reward,
-        description: `${giver} 報告蟲害，協助處理 ${pestCount} 塊農地的害蟲。`,
-        npcName: giver,
-      };
-    };
-
-    const combined = { ...preserved };
-    let slotIndex = 0;
-    while (Object.keys(combined).length < DYNAMIC_QUEST_SLOTS) {
-      const quest = buildQuest(slotIndex);
-      combined[quest.id] = quest;
-      slotIndex += 1;
-    }
-
-    setDynamicQuests(combined);
-    setQuestLog(prev => {
-      if (!prev) {
-        return prev;
-      }
-      const next = { ...prev };
-      Object.keys(prev).forEach(id => {
-        if (id.startsWith('daily_') && !combined[id]) {
-          delete next[id];
-        }
-      });
-      return next;
-    });
-  }, [setDynamicQuests, setQuestLog, stateRef]);
+  const stateRef = useRef({});
 
   const notificationCenter = useMemo(() => new NotificationCenter(setNotifications), []);
   const addNotification = useCallback((message, options) => {
@@ -284,9 +83,27 @@ const FarmGame = () => {
     notificationCenter.dismiss(id);
   }, [notificationCenter]);
 
+  const questManager = useMemo(() => new QuestManager({
+    stateRef,
+    setQuestLog,
+    setDynamicQuests,
+    setInventory,
+    setMoney,
+    notifier: addNotification,
+  }), [stateRef, setQuestLog, setDynamicQuests, setInventory, setMoney, addNotification]);
+
+  const questDefinitions = useMemo(
+    () => questManager.buildQuestDefinitions(dynamicQuests),
+    [questManager, dynamicQuests],
+  );
+
   useEffect(() => {
-    refreshDynamicQuests(day);
-  }, [day, refreshDynamicQuests]);
+    questManager.refreshDaily(day);
+  }, [questManager, day]);
+
+  const recordQuestEvent = useCallback((event) => {
+    questManager.recordEvent(event, questDefinitions);
+  }, [questManager, questDefinitions]);
 
   const farmSize = Array.isArray(farm) ? farm.length : 0;
   const nextFarmExpansionCost = useMemo(() => (
@@ -320,8 +137,6 @@ const FarmGame = () => {
   });
   const [saveData, setSaveData] = useState('');
   const [loadData, setLoadData] = useState('');
-
-  const stateRef = useRef({});
 
   stateRef.current = {
     money,
@@ -400,81 +215,6 @@ const FarmGame = () => {
     notifier: addNotification,
   }), [addNotification]);
 
-  const recordQuestEvent = useCallback((event) => {
-    if (!event?.type) {
-      return;
-    }
-
-    setQuestLog(prev => {
-      if (!prev || Object.keys(prev).length === 0) {
-        return prev;
-      }
-
-      let mutated = false;
-      const next = { ...prev };
-
-      Object.entries(prev).forEach(([questId, entry]) => {
-        if (!entry || (entry.status !== 'accepted' && entry.status !== 'ready')) {
-          return;
-        }
-
-        const quest = questDefinitions[questId];
-        if (!quest) {
-          return;
-        }
-
-        const required = quest.count ?? 0;
-        const currentProgress = entry.progress ?? 0;
-        let updatedEntry = entry;
-
-        switch (quest.type) {
-          case 'harvest':
-            if (event.type === 'harvest' && event.crop === quest.target) {
-              const newProgress = Math.min(required, currentProgress + (event.amount ?? 1));
-              if (newProgress !== currentProgress || entry.status !== 'ready') {
-                updatedEntry = { ...entry, progress: newProgress };
-                if (required > 0 && newProgress >= required) {
-                  updatedEntry.status = 'ready';
-                }
-              }
-            }
-            break;
-          case 'sell':
-            if (event.type === 'sell' && event.crop === quest.target) {
-              const newProgress = Math.min(required, currentProgress + (event.amount ?? 1));
-              if (newProgress !== currentProgress || entry.status !== 'ready') {
-                updatedEntry = { ...entry, progress: newProgress };
-                if (required > 0 && newProgress >= required) {
-                  updatedEntry.status = 'ready';
-                }
-              }
-            }
-            break;
-          case 'pestClear':
-            if (event.type === 'pestClear') {
-              const newProgress = Math.min(required, currentProgress + (event.amount ?? 1));
-              if (newProgress !== currentProgress || entry.status !== 'ready') {
-                updatedEntry = { ...entry, progress: newProgress };
-                if (required > 0 && newProgress >= required) {
-                  updatedEntry.status = 'ready';
-                }
-              }
-            }
-            break;
-          default:
-            break;
-        }
-
-        if (updatedEntry !== entry) {
-          next[questId] = updatedEntry;
-          mutated = true;
-        }
-      });
-
-      return mutated ? next : prev;
-    });
-  }, [questDefinitions]);
-
   const gameEngine = useMemo(() => new GameEngine({
     stateRef,
     setters: {
@@ -516,146 +256,26 @@ const FarmGame = () => {
   }, [sprinklerLevel]);
 
   const acceptQuest = useCallback((questId) => {
-    const quest = questDefinitions[questId];
-    if (!quest) {
-      return;
-    }
-
-    const existing = questLog[questId];
-    if (existing?.status === 'accepted' || existing?.status === 'ready') {
-      addNotification('任務已在進行中！', { type: 'info' });
-      return;
-    }
-    if (existing?.status === 'completed') {
-      addNotification('這項任務已經完成過囉！', { type: 'info' });
-      return;
-    }
-
-    setQuestLog(prev => ({
-      ...prev,
-      [questId]: {
-        status: 'accepted',
-        progress: 0,
-        acceptedDay: day,
-      },
-    }));
-    addNotification(`📜 接下任務：「${quest.description}」`, { type: 'info' });
-  }, [questDefinitions, questLog, setQuestLog, addNotification, day]);
+    questManager.acceptQuest(questId, questDefinitions, questLog, day);
+  }, [questManager, questDefinitions, questLog, day]);
 
   const deliverQuest = useCallback((questId) => {
-    const quest = questDefinitions[questId];
-    if (!quest || quest.type !== 'deliver') {
-      return;
-    }
-
-    const entry = questLog[questId];
-    if (!entry || entry.status !== 'accepted') {
-      if (entry?.status === 'completed') {
-        addNotification('任務已經交付完成。', { type: 'info' });
-      } else {
-        addNotification('請先接受任務再進行交付。', { type: 'warning' });
-      }
-      return;
-    }
-
-    const needCount = quest.count ?? 0;
-    const available = inventory?.[quest.target] ?? 0;
-    if (available < needCount) {
-      addNotification('庫存不足，無法完成交付。', { type: 'warning' });
-      return;
-    }
-
-    setInventory(prev => ({
-      ...prev,
-      [quest.target]: Math.max(0, (prev?.[quest.target] || 0) - needCount),
-    }));
-    setMoney(prev => prev + (quest.reward ?? 0));
-    setQuestLog(prev => ({
-      ...prev,
-      [questId]: {
-        ...prev[questId],
-        status: 'completed',
-        progress: needCount,
-        completedDay: day,
-      },
-    }));
-
-    const targetLabel = getQuestTargetLabel(quest);
-    addNotification(`🎁 已交付 ${needCount} 份${targetLabel}，獲得 $${quest.reward}！`, { type: 'success' });
-  }, [questDefinitions, questLog, inventory, setInventory, setMoney, setQuestLog, getQuestTargetLabel, addNotification, day]);
+    questManager.deliverQuest(questId, questDefinitions, questLog, inventory, day);
+  }, [questManager, questDefinitions, questLog, inventory, day]);
 
   const claimQuestReward = useCallback((questId) => {
-    const quest = questDefinitions[questId];
-    if (!quest) {
-      return;
-    }
-
-    const entry = questLog[questId];
-    if (!entry) {
-      addNotification('請先接受任務！', { type: 'info' });
-      return;
-    }
-
-    if (entry.status !== 'ready') {
-      if (entry.status === 'completed') {
-        addNotification('任務獎勵已經領取過了。', { type: 'info' });
-      } else {
-        addNotification('仍未達成任務要求，持續加油！', { type: 'warning' });
-      }
-      return;
-    }
-
-    setMoney(prev => prev + (quest.reward ?? 0));
-    setQuestLog(prev => ({
-      ...prev,
-      [questId]: {
-        ...prev[questId],
-        status: 'completed',
-        progress: quest.count ?? prev[questId]?.progress ?? 0,
-        completedDay: day,
-      },
-    }));
-    addNotification(`💰 領取任務獎勵 $${quest.reward}！`, { type: 'success' });
-  }, [questDefinitions, questLog, setMoney, setQuestLog, addNotification, day]);
+    questManager.claimQuestReward(questId, questDefinitions, questLog, day);
+  }, [questManager, questDefinitions, questLog, day]);
 
   const activeQuests = useMemo(() => {
-    if (!questLog) {
-      return [];
-    }
-
-    return Object.entries(questLog)
-      .map(([questId, entry]) => {
-        const quest = questDefinitions[questId];
-        if (!quest || entry.status === 'completed') {
-          return null;
-        }
-
-        const required = quest.count ?? 0;
-        const inventoryCount = quest.type === 'deliver' ? (inventory?.[quest.target] ?? 0) : null;
-        const progress = quest.type === 'deliver'
-          ? Math.min(required, inventoryCount ?? 0)
-          : Math.min(required, entry.progress ?? 0);
-        const ready = entry.status === 'ready'
-          || (quest.type === 'deliver' && entry.status === 'accepted' && inventoryCount != null && inventoryCount >= required);
-
-        return {
-          id: questId,
-          quest,
-          entry,
-          progress,
-          required,
-          ready,
-          inventoryCount,
-        };
-      })
-      .filter(Boolean)
-      .sort((a, b) => {
-        if (a.ready === b.ready) {
-          return 0;
-        }
-        return a.ready ? -1 : 1;
-      });
-  }, [questLog, questDefinitions, inventory]);
+    const list = questManager.getActiveQuests(questDefinitions, questLog, inventory);
+    return list.sort((a, b) => {
+      if (a.ready === b.ready) {
+        return 0;
+      }
+      return a.ready ? -1 : 1;
+    });
+  }, [questManager, questDefinitions, questLog, inventory]);
 
   const availableDynamicQuests = useMemo(() => {
     if (!dynamicQuests) {
@@ -1915,7 +1535,7 @@ const FarmGame = () => {
                   {activeQuests.map(({ id, quest, entry, progress, required, ready, inventoryCount }) => {
                     const badgeText = ready ? '可完成' : entry.status === 'accepted' ? '進行中' : '等待交付';
                     const badgeClass = ready ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600';
-                    const targetLabel = getQuestTargetLabel(quest);
+                    const targetLabel = questManager.getQuestTargetLabel(quest);
                     const needsText = required > 0 ? `需求：${targetLabel} x${required}` : '';
                     const progressText = required > 0
                       ? quest.type === 'deliver'
@@ -1979,7 +1599,7 @@ const FarmGame = () => {
                   <div className="space-y-2">
                     {availableDynamicQuests.map(({ id, quest }) => {
                       const required = quest.count ?? 0;
-                      const targetLabel = getQuestTargetLabel(quest);
+                      const targetLabel = questManager.getQuestTargetLabel(quest);
                       return (
                         <div key={id} className="border border-rose-100 rounded-lg p-3 bg-white/70">
                           <div className="flex items-start justify-between gap-2">
@@ -2855,7 +2475,7 @@ const FarmGame = () => {
                     statusLabel = '已完成';
                   }
 
-                  const targetLabel = getQuestTargetLabel(quest);
+                  const targetLabel = questManager.getQuestTargetLabel(quest);
 
                   return (
                     <div key={quest.id} className="border border-gray-200 rounded-lg p-3 bg-gray-50">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,8 @@ const createInitialInventory = () => {
   return base;
 };
 
+const DYNAMIC_QUEST_SLOTS = 3;
+
 const FarmGame = () => {
   // 基本狀態
   const [money, setMoney] = useState(500);
@@ -76,6 +78,7 @@ const FarmGame = () => {
   });
 
   const [questLog, setQuestLog] = useState({});
+  const [dynamicQuests, setDynamicQuests] = useState({});
 
   const [animals, setAnimals] = useState([]);
   const [animalCapacity, setAnimalCapacity] = useState(BASE_ANIMAL_CAPACITY);
@@ -113,8 +116,15 @@ const FarmGame = () => {
         }
       });
     });
+
+    Object.entries(dynamicQuests || {}).forEach(([questId, quest]) => {
+      if (questId && quest) {
+        map[questId] = quest;
+      }
+    });
+
     return map;
-  }, []);
+  }, [dynamicQuests]);
 
   const getQuestTargetLabel = useCallback((quest) => {
     if (!quest?.target) {
@@ -139,6 +149,133 @@ const FarmGame = () => {
     return quest.target;
   }, []);
 
+  const refreshDynamicQuests = useCallback((currentDay) => {
+    const existingDynamic = stateRef.current.dynamicQuests || {};
+    const existingLog = stateRef.current.questLog || {};
+
+    const preserved = {};
+    Object.entries(existingDynamic).forEach(([id, quest]) => {
+      const status = existingLog?.[id]?.status;
+      if (status === 'accepted' || status === 'ready') {
+        preserved[id] = quest;
+      }
+    });
+
+    const questGivers = ['商會佈告欄', '旅行商人', '鄰村里長', '合作社代表', '冒險者公會'];
+    const deliverTargets = [...Object.keys(CROPS), ...Object.keys(ANIMAL_PRODUCTS)];
+    const harvestTargets = Object.keys(CROPS);
+    const sellTargets = Object.keys(CROPS);
+
+    const randomBetween = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+    const pickOne = (list) => list[Math.floor(Math.random() * list.length)];
+
+    const usedIds = new Set(Object.keys(preserved));
+    const createQuestId = (slot) => {
+      let attempt = 0;
+      let id;
+      do {
+        id = `daily_${currentDay}_${slot}_${Math.random().toString(36).slice(2, 6)}`;
+        attempt += 1;
+      } while (usedIds.has(id) && attempt < 5);
+      usedIds.add(id);
+      return id;
+    };
+
+    const buildQuest = (slot) => {
+      const giver = pickOne(questGivers);
+      const questTypes = ['deliver', 'harvest', 'sell', 'pestClear'];
+      const type = pickOne(questTypes);
+      const questId = createQuestId(slot);
+
+      if (type === 'deliver' && deliverTargets.length > 0) {
+        const target = pickOne(deliverTargets);
+        const product = ANIMAL_PRODUCTS[target];
+        const crop = CROPS[target];
+        const isProduct = Boolean(product);
+        const label = isProduct
+          ? `${product.emoji} ${product.name}`
+          : `${crop.emoji} ${crop.name}`;
+        const basePrice = isProduct ? product.basePrice : crop.sellPrice;
+        const count = isProduct ? randomBetween(4, 12) : randomBetween(18, 45);
+        const reward = Math.max(150, Math.floor(basePrice * count * (isProduct ? 1.9 : 1.5)));
+        return {
+          id: questId,
+          type: 'deliver',
+          target,
+          count,
+          reward,
+          description: `${giver} 需要 ${count} 份${label}，協助供貨即可獲得酬勞。`,
+          npcName: giver,
+        };
+      }
+
+      if (type === 'harvest' && harvestTargets.length > 0) {
+        const target = pickOne(harvestTargets);
+        const crop = CROPS[target];
+        const count = randomBetween(10, 28);
+        const reward = Math.max(160, Math.floor(crop.sellPrice * count * (1.4 + Math.random() * 0.5)));
+        return {
+          id: questId,
+          type: 'harvest',
+          target,
+          count,
+          reward,
+          description: `${giver} 正準備市集，收成 ${count} 份${crop.emoji} ${crop.name} 就能領取獎金。`,
+          npcName: giver,
+        };
+      }
+
+      if (type === 'sell' && sellTargets.length > 0) {
+        const target = pickOne(sellTargets);
+        const crop = CROPS[target];
+        const count = randomBetween(15, 35);
+        const reward = Math.max(200, Math.floor(crop.sellPrice * count * (1.55 + Math.random() * 0.45)));
+        return {
+          id: questId,
+          type: 'sell',
+          target,
+          count,
+          reward,
+          description: `${giver} 想炒熱 ${crop.emoji} ${crop.name} 的行情，賣出 ${count} 份即可分紅。`,
+          npcName: giver,
+        };
+      }
+
+      const pestCount = randomBetween(3, 6);
+      const reward = randomBetween(180, 320);
+      return {
+        id: questId,
+        type: 'pestClear',
+        count: pestCount,
+        reward,
+        description: `${giver} 報告蟲害，協助處理 ${pestCount} 塊農地的害蟲。`,
+        npcName: giver,
+      };
+    };
+
+    const combined = { ...preserved };
+    let slotIndex = 0;
+    while (Object.keys(combined).length < DYNAMIC_QUEST_SLOTS) {
+      const quest = buildQuest(slotIndex);
+      combined[quest.id] = quest;
+      slotIndex += 1;
+    }
+
+    setDynamicQuests(combined);
+    setQuestLog(prev => {
+      if (!prev) {
+        return prev;
+      }
+      const next = { ...prev };
+      Object.keys(prev).forEach(id => {
+        if (id.startsWith('daily_') && !combined[id]) {
+          delete next[id];
+        }
+      });
+      return next;
+    });
+  }, [setDynamicQuests, setQuestLog, stateRef]);
+
   const notificationCenter = useMemo(() => new NotificationCenter(setNotifications), []);
   const addNotification = useCallback((message, options) => {
     notificationCenter.push(message, options);
@@ -146,6 +283,10 @@ const FarmGame = () => {
   const dismissNotification = useCallback((id) => {
     notificationCenter.dismiss(id);
   }, [notificationCenter]);
+
+  useEffect(() => {
+    refreshDynamicQuests(day);
+  }, [day, refreshDynamicQuests]);
 
   const farmSize = Array.isArray(farm) ? farm.length : 0;
   const nextFarmExpansionCost = useMemo(() => (
@@ -215,6 +356,7 @@ const FarmGame = () => {
     marketView,
     marketListSort,
     inventorySortMode,
+    dynamicQuests,
   };
 
   const saveManager = useMemo(() => new SaveManager({
@@ -253,6 +395,7 @@ const FarmGame = () => {
       setSelectedSupply,
       setShowSupplyShop,
       setPendingGreenhousePlacement,
+      setDynamicQuests,
     },
     notifier: addNotification,
   }), [addNotification]);
@@ -513,6 +656,22 @@ const FarmGame = () => {
         return a.ready ? -1 : 1;
       });
   }, [questLog, questDefinitions, inventory]);
+
+  const availableDynamicQuests = useMemo(() => {
+    if (!dynamicQuests) {
+      return [];
+    }
+
+    return Object.entries(dynamicQuests)
+      .map(([id, quest]) => {
+        const entry = questLog?.[id];
+        if (entry && (entry.status === 'accepted' || entry.status === 'ready')) {
+          return null;
+        }
+        return { id, quest };
+      })
+      .filter(Boolean);
+  }, [dynamicQuests, questLog]);
 
   const marketInsights = useMemo(() => {
     const entries = Object.entries(CROPS).map(([key, crop]) => {
@@ -1273,8 +1432,8 @@ const FarmGame = () => {
     }
   }, [gameEngine]);
 
-  const buyAnimal = useCallback((animalType) => {
-    gameEngine.buyAnimal(animalType);
+  const buyAnimal = useCallback((animalType, quantity = 1) => {
+    gameEngine.buyAnimal(animalType, { quantity });
   }, [gameEngine]);
 
   const buyBuilding = useCallback((buildingType) => {
@@ -1293,8 +1452,8 @@ const FarmGame = () => {
     gameEngine.feedAnimal(animalId);
   }, [gameEngine]);
 
-  const buySupply = useCallback((supplyType) => {
-    gameEngine.buySupply(supplyType);
+  const buySupply = useCallback((supplyType, quantity = 1) => {
+    gameEngine.buySupply(supplyType, { quantity });
   }, [gameEngine]);
 
   const selectSupply = useCallback((supplyType) => {
@@ -1813,6 +1972,42 @@ const FarmGame = () => {
                   目前沒有進行中的任務，去和鄰居聊聊看看是否需要幫忙吧！
                 </p>
               )}
+
+              <div className="mt-4 pt-3 border-t border-rose-100">
+                <h4 className="text-sm font-semibold text-rose-600 mb-2">今日佈告欄任務</h4>
+                {availableDynamicQuests.length > 0 ? (
+                  <div className="space-y-2">
+                    {availableDynamicQuests.map(({ id, quest }) => {
+                      const required = quest.count ?? 0;
+                      const targetLabel = getQuestTargetLabel(quest);
+                      return (
+                        <div key={id} className="border border-rose-100 rounded-lg p-3 bg-white/70">
+                          <div className="flex items-start justify-between gap-2">
+                            <div>
+                              <p className="text-sm font-semibold text-rose-700 leading-snug">{quest.description}</p>
+                              <p className="text-xs text-gray-600 mt-1">獎勵 ${quest.reward}</p>
+                              {required > 0 && targetLabel !== '目標' && (
+                                <p className="text-xs text-gray-500 mt-1">需求：{targetLabel} x{required}</p>
+                              )}
+                            </div>
+                            <span className="text-[11px] px-2 py-1 rounded-full bg-rose-100 text-rose-600">{quest.npcName}</span>
+                          </div>
+                          <div className="mt-2 flex justify-end">
+                            <button
+                              onClick={() => acceptQuest(id)}
+                              className="text-xs font-semibold px-3 py-1 rounded bg-rose-500 text-white hover:bg-rose-600 transition-colors"
+                            >
+                              接受任務
+                            </button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-xs text-gray-500">今日暫無新的佈告欄委託，明天再來看看吧！</p>
+                )}
+              </div>
             </div>
 
             {/* 市場價格 */}
@@ -2347,10 +2542,8 @@ const FarmGame = () => {
             <h2 className="text-xl font-bold mb-4">動物商店</h2>
             <div className="grid grid-cols-2 gap-4">
               {Object.entries(ANIMALS).map(([key, animal]) => (
-                <div key={key} 
-                     className="border rounded-lg p-4 cursor-pointer hover:bg-gray-50 transition-colors"
-                     onClick={() => buyAnimal(key)}>
-                  <div className="text-center">
+                <div key={key} className="border rounded-lg p-4 bg-white/90 shadow-sm">
+                  <div className="text-center space-y-1">
                     <div className="text-3xl mb-2">{animal.emoji}</div>
                     <div className="font-semibold">{animal.name}</div>
                     <div className="text-green-600 font-bold">${animal.price}</div>
@@ -2363,6 +2556,17 @@ const FarmGame = () => {
                     <div className="text-xs text-purple-600">
                       需要: {BUILDINGS[animal.shelter]?.name || '無'}
                     </div>
+                  </div>
+                  <div className="flex gap-2 mt-3">
+                    {[1, 3].map(amount => (
+                      <button
+                        key={amount}
+                        onClick={() => buyAnimal(key, amount)}
+                        className="flex-1 text-xs bg-blue-500/10 text-blue-700 border border-blue-200 hover:border-blue-400 rounded py-1 transition-colors"
+                      >
+                        購買 {amount}
+                      </button>
+                    ))}
                   </div>
                 </div>
               ))}
@@ -2540,9 +2744,7 @@ const FarmGame = () => {
             <h2 className="text-xl font-bold mb-4">農務用品商店</h2>
             <div className="space-y-4">
               {Object.entries(FARM_SUPPLIES).map(([key, supply]) => (
-                <div key={key}
-                     className="border rounded-lg p-4 cursor-pointer hover:bg-teal-50 transition-colors"
-                     onClick={() => buySupply(key)}>
+                <div key={key} className="border rounded-lg p-4 bg-white/95 shadow-sm">
                   <div className="flex justify-between items-start">
                     <div>
                       <div className="text-2xl">{supply.emoji}</div>
@@ -2550,6 +2752,17 @@ const FarmGame = () => {
                       <div className="text-sm text-gray-600 mt-1 leading-snug">{supply.description}</div>
                     </div>
                     <div className="text-green-600 font-bold">${supply.price}</div>
+                  </div>
+                  <div className="flex gap-2 mt-3">
+                    {[1, 3, 5].map(amount => (
+                      <button
+                        key={amount}
+                        onClick={() => buySupply(key, amount)}
+                        className="flex-1 text-xs bg-teal-500/10 text-teal-700 border border-teal-200 hover:border-teal-400 rounded py-1 transition-colors"
+                      >
+                        購買 {amount}
+                      </button>
+                    ))}
                   </div>
                 </div>
               ))}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,6 +77,10 @@ const FarmGame = () => {
   const [showLoadMenu, setShowLoadMenu] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [notifications, setNotifications] = useState([]);
+  const [pendingGreenhousePlacement, setPendingGreenhousePlacement] = useState(false);
+  const [marketView, setMarketView] = useState('summary');
+  const [marketListSort, setMarketListSort] = useState('price');
+  const [inventorySortMode, setInventorySortMode] = useState('value');
 
   const notificationCenter = useMemo(() => new NotificationCenter(setNotifications), []);
   const addNotification = useCallback((message, options) => {
@@ -148,6 +152,10 @@ const FarmGame = () => {
     selectedSeed,
     selectedSupply,
     loadData,
+    pendingGreenhousePlacement,
+    marketView,
+    marketListSort,
+    inventorySortMode,
   };
 
   const saveManager = useMemo(() => new SaveManager({
@@ -183,6 +191,7 @@ const FarmGame = () => {
       setSelectedSeed,
       setSelectedSupply,
       setShowSupplyShop,
+      setPendingGreenhousePlacement,
     },
     notifier: addNotification,
   }), [addNotification]);
@@ -207,6 +216,7 @@ const FarmGame = () => {
       setShowBuildingShop,
       setTools,
       setShowToolShop,
+      setPendingGreenhousePlacement,
     },
     notifier: addNotification,
   }), [stateRef, addNotification]);
@@ -289,7 +299,15 @@ const FarmGame = () => {
       });
     });
 
-    const sortedItems = items.sort((a, b) => {
+    const sortedItems = [...items];
+    sortedItems.sort((a, b) => {
+      if (inventorySortMode === 'count') {
+        if (b.count === a.count) {
+          return b.totalValue - a.totalValue;
+        }
+        return b.count - a.count;
+      }
+
       if (b.totalValue === a.totalValue) {
         return b.count - a.count;
       }
@@ -313,7 +331,50 @@ const FarmGame = () => {
       totalCount: safeTotalCount,
       totalValue: Math.round(safeTotalValue),
     };
-  }, [inventory, gameEngine, animals, buildings, marketPrices]);
+  }, [inventory, gameEngine, animals, buildings, marketPrices, inventorySortMode]);
+
+  const buildingEntries = useMemo(() => {
+    if (!buildings) {
+      return [];
+    }
+
+    return Object.entries(buildings)
+      .filter(([key, value]) => {
+        if (!BUILDINGS[key]) {
+          return false;
+        }
+
+        if (typeof value === 'number') {
+          return value > 0;
+        }
+
+        return Boolean(value);
+      })
+      .map(([key, value]) => ({
+        key,
+        value,
+        meta: BUILDINGS[key],
+        count: typeof value === 'number' ? value : null,
+      }));
+  }, [buildings]);
+
+  const sortedMarketEntries = useMemo(() => {
+    const baseEntries = marketInsights.entries ? [...marketInsights.entries] : [];
+
+    switch (marketListSort) {
+      case 'premium':
+        baseEntries.sort((a, b) => (b.percentFromBase ?? 0) - (a.percentFromBase ?? 0));
+        break;
+      case 'change':
+        baseEntries.sort((a, b) => (b.changeFromPrevious ?? 0) - (a.changeFromPrevious ?? 0));
+        break;
+      default:
+        baseEntries.sort((a, b) => b.price - a.price);
+        break;
+    }
+
+    return baseEntries;
+  }, [marketInsights.entries, marketListSort]);
 
   const saveToSlot = useCallback((slotName) => {
     saveManager.saveToSlot(slotName);
@@ -815,6 +876,8 @@ const FarmGame = () => {
 
   const applySupply = useCallback((plotId) => gameEngine.applySupply(plotId), [gameEngine]);
 
+  const placeGreenhouse = useCallback((plotId) => gameEngine.placeGreenhouse(plotId), [gameEngine]);
+
   const treatAnimal = useCallback((animalId) => {
     gameEngine.treatAnimal(animalId);
   }, [gameEngine]);
@@ -947,61 +1010,97 @@ const FarmGame = () => {
             </div>
             
             {/* 農場格子 */}
+            {pendingGreenhousePlacement && (
+              <div className="mb-3 rounded-lg border border-teal-300 bg-teal-50 px-3 py-2 text-sm text-teal-700 flex items-center gap-2">
+                <Building className="w-4 h-4" />
+                已購買溫室模組，請點選一格尚未設置溫室的農地完成建造。
+              </div>
+            )}
             <div className="grid grid-cols-5 gap-2 mb-4">
-              {farm.map((plot) => (
-                <div key={plot.id}
-                     className={`aspect-square border-2 rounded-lg cursor-pointer transition-all duration-300 hover:scale-105 relative ${
-                       plot.greenhouse ? 'border-green-600 bg-green-50' :
-                       plot.crop
-                         ? plot.ready
-                           ? 'bg-green-200 border-green-400 animate-pulse'
-                           : 'bg-yellow-100 border-yellow-400'
-                         : 'bg-gray-100 border-gray-300 hover:bg-green-50'
-                     }`}
-                     onClick={() => {
-                       if (selectedSupply) {
-                         const handled = applySupply(plot.id);
-                         if (handled) {
-                           return;
-                         }
-                       }
+              {farm.map((plot) => {
+                const isReady = Boolean(plot.crop && plot.ready);
+                const isGreenhouse = Boolean(plot.greenhouse);
+                const isEmpty = !plot.crop;
+                const highlightForPlacement = pendingGreenhousePlacement && !isGreenhouse;
 
-                       if (plot.crop && plot.ready) {
-                         harvestCrop(plot.id);
-                       } else if (!plot.crop && selectedSeed) {
-                         plantSeed(plot.id);
-                       } else if (plot.crop && !plot.watered) {
-                         waterPlot(plot.id);
-                       }
-                     }}>
-                  <div className="h-full flex flex-col items-center justify-center text-2xl">
-                    {plot.greenhouse && (
-                      <div className="absolute top-0 right-0 text-xs">🏢</div>
-                    )}
-                    {plot.pest && (
-                      <div className="absolute top-0 left-0 text-xs animate-bounce">🐛</div>
-                    )}
-                    {plot.fertilized && !plot.ready && (
-                      <div className="absolute bottom-1 right-1 text-xs">🌿</div>
-                    )}
-                    {plot.crop ? (
-                      <>
-                        <div className={`transform transition-transform duration-500 ${
-                          plot.ready ? 'scale-125 animate-bounce' : 'scale-100'
-                        }`}>
-                          {CROPS[plot.crop].emoji}
-                        </div>
-                        <div className="flex absolute bottom-0 left-0 right-0 justify-center">
-                          {plot.watered && <Droplets className="w-3 h-3 text-blue-400" />}
-                        </div>
-                      </>
-                    ) : (
-                      selectedSeed && <div className="text-gray-400">+</div>
-                    )}
+                let tileStyle = '';
+                if (isReady) {
+                  tileStyle = 'bg-amber-200 border-amber-500 animate-pulse';
+                } else if (isGreenhouse) {
+                  tileStyle = isEmpty
+                    ? 'bg-teal-50 border-teal-400'
+                    : 'bg-teal-100 border-teal-400';
+                } else if (plot.crop) {
+                  tileStyle = 'bg-lime-100 border-lime-400';
+                } else {
+                  tileStyle = 'bg-gray-100 border-gray-300 hover:bg-green-50';
+                }
+
+                const placementRing = highlightForPlacement
+                  ? 'ring-2 ring-teal-400 ring-offset-2'
+                  : '';
+
+                return (
+                  <div key={plot.id}
+                       className={`aspect-square border-2 rounded-lg cursor-pointer transition-all duration-300 hover:scale-105 relative ${tileStyle} ${placementRing}`}
+                       onClick={() => {
+                         if (pendingGreenhousePlacement) {
+                           const handled = placeGreenhouse(plot.id);
+                           if (handled) {
+                             return;
+                           }
+                         }
+
+                         if (selectedSupply) {
+                           const handled = applySupply(plot.id);
+                           if (handled) {
+                             return;
+                           }
+                         }
+
+                         if (plot.crop && plot.ready) {
+                           harvestCrop(plot.id);
+                         } else if (!plot.crop && selectedSeed) {
+                           plantSeed(plot.id);
+                         } else if (plot.crop && !plot.watered) {
+                           waterPlot(plot.id);
+                         }
+                       }}>
+                    <div className="h-full flex flex-col items-center justify-center text-2xl">
+                      {plot.greenhouse && (
+                        <div className="absolute top-0 right-0 text-xs">🏢</div>
+                      )}
+                      {plot.pest && (
+                        <div className="absolute top-0 left-0 text-xs animate-bounce">🐛</div>
+                      )}
+                      {plot.fertilized && !plot.ready && (
+                        <div className="absolute bottom-1 right-1 text-xs">🌿</div>
+                      )}
+                      {plot.crop ? (
+                        <>
+                          <div className={`transform transition-transform duration-500 ${
+                            plot.ready ? 'scale-125 animate-bounce' : 'scale-100'
+                          }`}>
+                            {CROPS[plot.crop].emoji}
+                          </div>
+                          <div className="flex absolute bottom-0 left-0 right-0 justify-center">
+                            {plot.watered && <Droplets className="w-3 h-3 text-blue-400" />}
+                          </div>
+                        </>
+                      ) : (
+                        selectedSeed && <div className="text-gray-400">+</div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
+            {buildings?.sprinkler && (
+              <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-700 flex items-center gap-2">
+                <Droplets className="w-3 h-3" />
+                自動灑水器會在每日清晨為尚未成熟的作物補水，並降低人工澆水所需體力。
+              </div>
+            )}
 
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-6 text-sm text-gray-700">
               <div>
@@ -1020,15 +1119,18 @@ const FarmGame = () => {
             </div>
 
             {/* 建築展示 */}
-            {Object.keys(buildings).length > 0 && (
+            {buildingEntries.length > 0 && (
               <div className="mt-4">
                 <h3 className="text-lg font-bold mb-2">建築設施</h3>
                 <div className="flex flex-wrap gap-2">
-                  {Object.keys(buildings).map(buildingType => (
-                    <div key={buildingType} 
+                  {buildingEntries.map(entry => (
+                    <div key={entry.key}
                          className="bg-blue-100 rounded-lg p-2 flex items-center space-x-2">
-                      <span className="text-2xl">{BUILDINGS[buildingType].emoji}</span>
-                      <span className="text-sm font-semibold">{BUILDINGS[buildingType].name}</span>
+                      <span className="text-2xl">{entry.meta.emoji}</span>
+                      <span className="text-sm font-semibold">
+                        {entry.meta.name}
+                        {entry.key === 'greenhouse' && entry.count ? ` x${entry.count}` : ''}
+                      </span>
                     </div>
                   ))}
                 </div>
@@ -1192,14 +1294,30 @@ const FarmGame = () => {
 
             {/* 市場價格 */}
             <div className="bg-white bg-opacity-90 rounded-lg p-4 shadow-lg">
-              <div className="flex items-center justify-between mb-3">
+              <div className="flex flex-wrap items-start justify-between gap-2 mb-3">
                 <h3 className="text-lg font-bold flex items-center gap-2">
                   <TrendingUp className="w-4 h-4 text-green-600" />
                   市場價格
                 </h3>
-                <div className="flex items-center gap-1 text-xs text-gray-500">
-                  <Clock3 className="w-3 h-3" />
-                  <span>{marketUpdateTime ? new Date(marketUpdateTime).toLocaleTimeString('zh-TW', { hour: '2-digit', minute: '2-digit' }) : '更新中…'}</span>
+                <div className="flex flex-col items-end gap-2 text-xs">
+                  <div className="flex items-center gap-1 text-gray-500">
+                    <Clock3 className="w-3 h-3" />
+                    <span>{marketUpdateTime ? new Date(marketUpdateTime).toLocaleTimeString('zh-TW', { hour: '2-digit', minute: '2-digit' }) : '更新中…'}</span>
+                  </div>
+                  <div className="flex items-center gap-1 bg-gray-100 rounded-full p-1">
+                    <button
+                      onClick={() => setMarketView('summary')}
+                      className={`px-2 py-1 rounded-full transition-colors ${marketView === 'summary' ? 'bg-green-500 text-white' : 'text-gray-600 hover:text-green-600'}`}
+                    >
+                      日常總覽
+                    </button>
+                    <button
+                      onClick={() => setMarketView('list')}
+                      className={`px-2 py-1 rounded-full transition-colors ${marketView === 'list' ? 'bg-green-500 text-white' : 'text-gray-600 hover:text-green-600'}`}
+                    >
+                      完整列表
+                    </button>
+                  </div>
                 </div>
               </div>
               <div className="bg-slate-50 border border-slate-200 rounded-lg p-2 mb-3">
@@ -1216,89 +1334,155 @@ const FarmGame = () => {
                   ></div>
                 </div>
               </div>
-              {marketInsights.risers.length > 0 && (
-                <div className="mb-3">
-                  <div className="flex items-center gap-1 text-xs font-semibold text-green-600 uppercase tracking-wide">
-                    <TrendingUp className="w-3 h-3" />
-                    漲勢領先
-                  </div>
-                  <div className="mt-1 space-y-1">
-                    {marketInsights.risers.map(entry => {
-                      const percentText = entry.percentFromPrevious != null ? entry.percentFromPrevious.toFixed(1) : '—';
-                      const percentDisplay = percentText === '—' ? '—' : `${percentText}%`;
-                      return (
-                        <div key={`rise-${entry.key}`} className="flex items-center justify-between text-xs bg-green-50 border border-green-100 rounded px-2 py-1 text-green-700">
-                          <span>{entry.emoji} {entry.name}</span>
-                          <span>
-                            +${entry.changeFromPrevious} ({percentDisplay})
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-              {marketInsights.fallers.length > 0 && (
-                <div className="mb-3">
-                  <div className="flex items-center gap-1 text-xs font-semibold text-red-600 uppercase tracking-wide">
-                    <TrendingDown className="w-3 h-3" />
-                    價格回落
-                  </div>
-                  <div className="mt-1 space-y-1">
-                    {marketInsights.fallers.map(entry => {
-                      const percentText = entry.percentFromPrevious != null ? Math.abs(entry.percentFromPrevious).toFixed(1) : '—';
-                      const percentDisplay = percentText === '—' ? '—' : `${percentText}%`;
-                      return (
-                        <div key={`fall-${entry.key}`} className="flex items-center justify-between text-xs bg-red-50 border border-red-100 rounded px-2 py-1 text-red-700">
-                          <span>{entry.emoji} {entry.name}</span>
-                          <span>
-                            -${Math.abs(entry.changeFromPrevious)} ({percentDisplay})
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              )}
-              <div className="space-y-2 border-t border-slate-200 pt-2">
-                {marketInsights.sortedByPremium.slice(0, 5).map(entry => {
-                  const trend = entry.changeFromPrevious ?? 0;
-                  const trendClass = trend > 0 ? 'text-green-600' : trend < 0 ? 'text-red-600' : 'text-gray-500';
-                  const premiumClass = entry.changeFromBase > 0 ? 'text-green-600' : entry.changeFromBase < 0 ? 'text-red-600' : 'text-gray-600';
-                  const percentFromPrevious = entry.percentFromPrevious != null ? entry.percentFromPrevious.toFixed(1) : '—';
-                  const premiumPercent = `${entry.percentFromBase >= 0 ? '+' : ''}${entry.percentFromBase.toFixed(1)}%`;
-                  const priceShare = marketInsights.highestPrice > 0 ? Math.min(100, Math.max(6, (entry.price / marketInsights.highestPrice) * 100)) : 0;
-
-                  return (
-                    <div key={entry.key} className="rounded-lg border border-slate-200 p-2">
-                      <div className="flex justify-between items-center text-sm font-semibold text-slate-800">
-                        <span>{entry.emoji} {entry.name}</span>
-                        <span>${entry.price}</span>
+              {marketView === 'summary' ? (
+                <>
+                  {marketInsights.risers.length > 0 && (
+                    <div className="mb-3">
+                      <div className="flex items-center gap-1 text-xs font-semibold text-green-600 uppercase tracking-wide">
+                        <TrendingUp className="w-3 h-3" />
+                        漲勢領先
                       </div>
-                      <div className="flex justify-between text-xs mt-1 text-slate-500">
-                        <span>基準 ${entry.basePrice}</span>
-                        <span className={premiumClass}>
-                          {entry.changeFromBase >= 0 ? '+' : ''}{entry.changeFromBase} ({premiumPercent})
-                        </span>
-                      </div>
-                      <div className="flex justify-between text-xs mt-1">
-                        <span className={trendClass}>
-                          {trend > 0 ? `▲ +${trend}` : trend < 0 ? `▼ ${trend}` : '→ 持平'}
-                        </span>
-                        <span className={trendClass}>
-                          {percentFromPrevious !== '—' ? `${trend > 0 ? '+' : ''}${percentFromPrevious}%` : '—'}
-                        </span>
-                      </div>
-                      <div className="bg-slate-100 h-1 rounded-full overflow-hidden mt-2">
-                        <div
-                          className="bg-slate-400 h-full transition-all"
-                          style={{ width: `${priceShare}%` }}
-                        ></div>
+                      <div className="mt-1 space-y-1">
+                        {marketInsights.risers.map(entry => {
+                          const percentText = entry.percentFromPrevious != null ? entry.percentFromPrevious.toFixed(1) : '—';
+                          const percentDisplay = percentText === '—' ? '—' : `${percentText}%`;
+                          return (
+                            <div key={`rise-${entry.key}`} className="flex items-center justify-between text-xs bg-green-50 border border-green-100 rounded px-2 py-1 text-green-700">
+                              <span>{entry.emoji} {entry.name}</span>
+                              <span>
+                                +${entry.changeFromPrevious} ({percentDisplay})
+                              </span>
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
-                  );
-                })}
-              </div>
+                  )}
+                  {marketInsights.fallers.length > 0 && (
+                    <div className="mb-3">
+                      <div className="flex items-center gap-1 text-xs font-semibold text-red-600 uppercase tracking-wide">
+                        <TrendingDown className="w-3 h-3" />
+                        價格回落
+                      </div>
+                      <div className="mt-1 space-y-1">
+                        {marketInsights.fallers.map(entry => {
+                          const percentText = entry.percentFromPrevious != null ? Math.abs(entry.percentFromPrevious).toFixed(1) : '—';
+                          const percentDisplay = percentText === '—' ? '—' : `${percentText}%`;
+                          return (
+                            <div key={`fall-${entry.key}`} className="flex items-center justify-between text-xs bg-red-50 border border-red-100 rounded px-2 py-1 text-red-700">
+                              <span>{entry.emoji} {entry.name}</span>
+                              <span>
+                                -${Math.abs(entry.changeFromPrevious)} ({percentDisplay})
+                              </span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                  <div className="space-y-2 border-t border-slate-200 pt-2">
+                    {marketInsights.sortedByPremium.slice(0, 5).map(entry => {
+                      const trend = entry.changeFromPrevious ?? 0;
+                      const trendClass = trend > 0 ? 'text-green-600' : trend < 0 ? 'text-red-600' : 'text-gray-500';
+                      const premiumClass = entry.changeFromBase > 0 ? 'text-green-600' : entry.changeFromBase < 0 ? 'text-red-600' : 'text-gray-600';
+                      const percentFromPrevious = entry.percentFromPrevious != null ? entry.percentFromPrevious.toFixed(1) : '—';
+                      const premiumPercent = `${entry.percentFromBase >= 0 ? '+' : ''}${entry.percentFromBase.toFixed(1)}%`;
+                      const priceShare = marketInsights.highestPrice > 0 ? Math.min(100, Math.max(6, (entry.price / marketInsights.highestPrice) * 100)) : 0;
+
+                      return (
+                        <div key={entry.key} className="rounded-lg border border-slate-200 p-2">
+                          <div className="flex justify-between items-center text-sm font-semibold text-slate-800">
+                            <span>{entry.emoji} {entry.name}</span>
+                            <span>${entry.price}</span>
+                          </div>
+                          <div className="flex justify-between text-xs mt-1 text-slate-500">
+                            <span>基準 ${entry.basePrice}</span>
+                            <span className={premiumClass}>
+                              {entry.changeFromBase >= 0 ? '+' : ''}{entry.changeFromBase} ({premiumPercent})
+                            </span>
+                          </div>
+                          <div className="flex justify-between text-xs mt-1">
+                            <span className={trendClass}>
+                              {trend > 0 ? `▲ +${trend}` : trend < 0 ? `▼ ${trend}` : '→ 持平'}
+                            </span>
+                            <span className={trendClass}>
+                              {percentFromPrevious !== '—' ? `${trend > 0 ? '+' : ''}${percentFromPrevious}%` : '—'}
+                            </span>
+                          </div>
+                          <div className="bg-slate-100 h-1 rounded-full overflow-hidden mt-2">
+                            <div
+                              className="bg-slate-400 h-full transition-all"
+                              style={{ width: `${priceShare}%` }}
+                            ></div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="flex justify-end mb-2">
+                    <div className="flex items-center gap-1 text-[11px] text-gray-600 bg-gray-100 rounded-full px-2 py-1">
+                      排序：
+                      <button
+                        onClick={() => setMarketListSort('price')}
+                        className={`px-2 py-[2px] rounded-full transition-colors ${marketListSort === 'price' ? 'bg-green-500 text-white' : 'text-gray-600 hover:text-green-600'}`}
+                      >
+                        價格
+                      </button>
+                      <button
+                        onClick={() => setMarketListSort('premium')}
+                        className={`px-2 py-[2px] rounded-full transition-colors ${marketListSort === 'premium' ? 'bg-green-500 text-white' : 'text-gray-600 hover:text-green-600'}`}
+                      >
+                        較基準
+                      </button>
+                      <button
+                        onClick={() => setMarketListSort('change')}
+                        className={`px-2 py-[2px] rounded-full transition-colors ${marketListSort === 'change' ? 'bg-green-500 text-white' : 'text-gray-600 hover:text-green-600'}`}
+                      >
+                        較昨日
+                      </button>
+                    </div>
+                  </div>
+                  <div className="border border-slate-200 rounded-lg overflow-hidden">
+                    <div className="grid grid-cols-4 gap-2 px-3 py-2 text-xs font-semibold text-slate-600 bg-slate-100">
+                      <span>作物</span>
+                      <span className="text-right">現價</span>
+                      <span className="text-right">對基準</span>
+                      <span className="text-right">對昨日</span>
+                    </div>
+                    {sortedMarketEntries.length > 0 ? (
+                      sortedMarketEntries.map(entry => {
+                        const baseChange = entry.changeFromBase ?? 0;
+                        const basePercent = entry.percentFromBase ?? 0;
+                        const baseClass = baseChange > 0 ? 'text-green-600' : baseChange < 0 ? 'text-red-600' : 'text-slate-500';
+                        const change = entry.changeFromPrevious ?? 0;
+                        const changePercent = entry.percentFromPrevious ?? 0;
+                        const changeClass = change > 0 ? 'text-green-600' : change < 0 ? 'text-red-600' : 'text-slate-500';
+                        const changeDisplay = entry.changeFromPrevious == null ? '—' : `${change > 0 ? '+' : ''}${change} (${changePercent >= 0 ? '+' : ''}${changePercent.toFixed(1)}%)`;
+                        const baseDisplay = `${baseChange >= 0 ? '+' : ''}${baseChange} (${basePercent >= 0 ? '+' : ''}${basePercent.toFixed(1)}%)`;
+
+                        return (
+                          <div key={`list-${entry.key}`} className="grid grid-cols-4 gap-2 px-3 py-2 text-xs border-t border-slate-100">
+                            <span className="flex items-center gap-2 font-medium text-slate-700">
+                              <span>{entry.emoji}</span>
+                              {entry.name}
+                            </span>
+                            <span className="text-right font-semibold text-slate-800">${entry.price}</span>
+                            <span className={`text-right ${baseClass}`}>{baseDisplay}</span>
+                            <span className={`text-right ${changeClass}`}>{changeDisplay}</span>
+                          </div>
+                        );
+                      })
+                    ) : (
+                      <div className="px-3 py-4 text-xs text-center text-slate-500 border-t border-slate-100">
+                        暫無市場資料。
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
             </div>
 
             {/* 庫存 */}
@@ -1316,6 +1500,25 @@ const FarmGame = () => {
                   <div className="text-amber-600 font-semibold">估值 ${inventoryInsights.totalValue}</div>
                 </div>
               </div>
+              {inventoryInsights.items.length > 0 && (
+                <div className="flex justify-end mb-2">
+                  <div className="flex items-center gap-1 text-[11px] text-amber-700 bg-amber-100 rounded-full px-2 py-1">
+                    排序：
+                    <button
+                      onClick={() => setInventorySortMode('value')}
+                      className={`px-2 py-[2px] rounded-full transition-colors ${inventorySortMode === 'value' ? 'bg-amber-500 text-white' : 'text-amber-700 hover:text-amber-900'}`}
+                    >
+                      總價值
+                    </button>
+                    <button
+                      onClick={() => setInventorySortMode('count')}
+                      className={`px-2 py-[2px] rounded-full transition-colors ${inventorySortMode === 'count' ? 'bg-amber-500 text-white' : 'text-amber-700 hover:text-amber-900'}`}
+                    >
+                      數量
+                    </button>
+                  </div>
+                </div>
+              )}
               {inventoryInsights.items.length > 0 ? (
                 <div className="space-y-2">
                   {inventoryInsights.items.map(item => {
@@ -1607,31 +1810,55 @@ const FarmGame = () => {
           <div className="bg-white rounded-lg p-6 max-w-3xl w-full mx-4 max-h-96 overflow-y-auto">
             <h2 className="text-xl font-bold mb-4">建築商店</h2>
             <div className="grid grid-cols-2 gap-4">
-              {Object.entries(BUILDINGS).map(([key, building]) => (
-                <div key={key} 
-                     className={`border rounded-lg p-4 cursor-pointer transition-colors ${
-                       buildings[key] 
-                         ? 'bg-green-100 border-green-400' 
-                         : 'hover:bg-gray-50'
-                     }`}
-                     onClick={() => buyBuilding(key)}>
-                  <div className="text-center">
-                    <div className="text-3xl mb-2">{building.emoji}</div>
-                    <div className="font-semibold">{building.name}</div>
-                    <div className={`font-bold ${buildings[key] ? 'text-green-600' : 'text-green-600'}`}>
-                      {buildings[key] ? '已擁有' : `${building.price}`}
-                    </div>
-                    <div className="text-xs text-gray-600 mt-2">
-                      {building.description}
-                    </div>
-                    {building.boost !== 1.0 && (
-                      <div className="text-xs text-blue-600">
-                        效果加成: {Math.round(building.boost * 100)}%
+              {Object.entries(BUILDINGS).map(([key, building]) => {
+                const rawValue = buildings?.[key];
+                const isGreenhouse = key === 'greenhouse';
+                const greenhouseCount = isGreenhouse
+                  ? (typeof rawValue === 'number'
+                    ? rawValue
+                    : (rawValue && Array.isArray(farm) ? farm.filter(plot => plot.greenhouse).length : 0))
+                  : 0;
+                const isOwned = isGreenhouse ? greenhouseCount > 0 : Boolean(rawValue);
+                const canPurchase = isGreenhouse || !isOwned;
+                const cardHighlight = isGreenhouse && greenhouseCount > 0
+                  ? 'bg-teal-50 border-teal-300'
+                  : isOwned
+                    ? 'bg-green-100 border-green-400'
+                    : 'hover:bg-gray-50';
+
+                return (
+                  <div key={key}
+                       className={`border rounded-lg p-4 transition-colors ${cardHighlight} ${canPurchase ? 'cursor-pointer' : 'cursor-not-allowed opacity-80'}`}
+                       onClick={() => canPurchase && buyBuilding(key)}>
+                    <div className="text-center">
+                      <div className="text-3xl mb-2">{building.emoji}</div>
+                      <div className="font-semibold">{building.name}</div>
+                      <div className={`font-bold ${isOwned && !isGreenhouse ? 'text-green-600' : 'text-green-600'}`}>
+                        {isGreenhouse
+                          ? `$${building.price}`
+                          : isOwned
+                            ? '已擁有'
+                            : `$${building.price}`}
                       </div>
-                    )}
+                      <div className="text-xs text-gray-600 mt-2 space-y-1">
+                        <p>{building.description}</p>
+                        {isGreenhouse && (
+                          <p className="text-teal-600">
+                            {greenhouseCount > 0
+                              ? `目前共有 ${greenhouseCount} 格溫室土地，可再購買擴充。`
+                              : '每次購買可讓一格農地升級為溫室。'}
+                          </p>
+                        )}
+                      </div>
+                      {building.boost !== 1.0 && (
+                        <div className="text-xs text-blue-600">
+                          效果加成: {Math.round(building.boost * 100)}%
+                        </div>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
             <button onClick={() => setShowBuildingShop(false)}
                     className="mt-4 w-full bg-gray-500 hover:bg-gray-600 text-white py-2 px-4 rounded transition-colors">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,25 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed } from 'lucide-react';
-import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS, FARM_SUPPLIES } from './game/data/GameCatalog';
+import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from './game/data/GameCatalog';
 import { GameFormatter } from './game/utils/GameFormatter';
-import { GameEngine } from './game/engine/GameEngine';
+import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY } from './game/engine/GameEngine';
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
+
+const INVENTORY_METADATA = {
+  ...Object.fromEntries(Object.entries(CROPS).map(([key, crop]) => [key, { name: crop.name, emoji: crop.emoji, type: 'crop' }])),
+  ...Object.fromEntries(Object.entries(ANIMAL_PRODUCTS).map(([key, product]) => [key, { name: product.name, emoji: product.emoji, type: 'product' }])),
+};
+
+const INVENTORY_ORDER = Object.keys(INVENTORY_METADATA);
+
+const createInitialInventory = () => {
+  const base = {};
+  INVENTORY_ORDER.forEach(key => {
+    base[key] = 0;
+  });
+  return base;
+};
 
 const FarmGame = () => {
   // 基本狀態
@@ -19,12 +34,10 @@ const FarmGame = () => {
   const [weatherDuration, setWeatherDuration] = useState(5);
   
   // 遊戲數據
-  const [inventory, setInventory] = useState({
-    carrot: 0, corn: 0, tomato: 0, wheat: 0, potato: 0, strawberry: 0
-  });
+  const [inventory, setInventory] = useState(() => createInitialInventory());
   
   const [farm, setFarm] = useState(
-    Array(25).fill().map((_, i) => ({
+    Array(BASE_FARM_PLOTS).fill().map((_, i) => ({
       id: i,
       crop: null,
       plantTime: null,
@@ -44,6 +57,7 @@ const FarmGame = () => {
   });
 
   const [animals, setAnimals] = useState([]);
+  const [animalCapacity, setAnimalCapacity] = useState(BASE_ANIMAL_CAPACITY);
   const [buildings, setBuildings] = useState({});
   const [tools, setTools] = useState('basic');
 
@@ -71,6 +85,19 @@ const FarmGame = () => {
   const dismissNotification = useCallback((id) => {
     notificationCenter.dismiss(id);
   }, [notificationCenter]);
+
+  const farmSize = Array.isArray(farm) ? farm.length : 0;
+  const nextFarmExpansionCost = useMemo(() => (
+    farmSize < MAX_FARM_PLOTS
+      ? getFarmExpansionCost(farmSize)
+      : null
+  ), [farmSize]);
+
+  const nextAnimalExpansionCost = useMemo(() => (
+    animalCapacity < MAX_ANIMAL_CAPACITY
+      ? getAnimalHousingExpansionCost(animalCapacity)
+      : null
+  ), [animalCapacity]);
   
   // 新功能狀態
   const [completedAchievements, setCompletedAchievements] = useState(new Set());
@@ -106,6 +133,7 @@ const FarmGame = () => {
     farm,
     farmSupplies,
     animals,
+    animalCapacity,
     buildings,
     tools,
     completedAchievements,
@@ -133,6 +161,7 @@ const FarmGame = () => {
       setInventory,
       setFarm,
       setAnimals,
+      setAnimalCapacity,
       setBuildings,
       setTools,
       setFarmSupplies,
@@ -166,6 +195,7 @@ const FarmGame = () => {
       setInventory,
       setFarmSupplies,
       setAnimals,
+      setAnimalCapacity,
       setShowAnimalShop,
       setBuildings,
       setShowBuildingShop,
@@ -220,6 +250,7 @@ const FarmGame = () => {
         safeAnimals.some(a => a.sick) ? '🤒 有動物生病了，使用營養劑能幫助牠們恢復。' : '',
         safeFarm.some(plot => plot.pest) ? '🐛 有作物遭害蟲啃食，記得噴灑驅蟲劑！' : '',
         Object.values(safeInventory).some(count => count > 10) ? '📦 庫存充足，可以考慮出售！' : '',
+        Object.keys(ANIMAL_PRODUCTS).some(key => (safeInventory[key] || 0) > 0) ? '🥚 動物產物已入庫，記得賣出換現金！' : '',
       ].filter(Boolean);
 
       if (advices.length > 0) {
@@ -307,6 +338,7 @@ const FarmGame = () => {
           setEnergy(100);
 
           // 動物每日狀態與收入結算
+          const producedGoods = {};
           setAnimals(prevAnimals => {
             if (!Array.isArray(prevAnimals) || prevAnimals.length === 0) {
               return prevAnimals;
@@ -364,9 +396,17 @@ const FarmGame = () => {
                 sickAnimals.push(animal.name);
               }
 
-              const income = canProduce
-                ? Math.floor(animalData.income * boost * (happiness / 100))
-                : 0;
+              let income = 0;
+              if (canProduce) {
+                if (animalData.product && ANIMAL_PRODUCTS[animalData.product]) {
+                  const productKey = animalData.product;
+                  const baseUnits = 1;
+                  const units = Math.max(1, Math.round(baseUnits * boost * (happiness / 100)));
+                  producedGoods[productKey] = (producedGoods[productKey] || 0) + units;
+                } else {
+                  income = Math.floor(animalData.income * boost * (happiness / 100));
+                }
+              }
               totalIncome += income;
 
               if (!sick && hunger >= 75 && happiness >= 75 && newbornAnimals.length < 3) {
@@ -430,6 +470,24 @@ const FarmGame = () => {
 
             return [...updatedAnimals, ...newbornAnimals];
           });
+
+          if (Object.keys(producedGoods).length > 0) {
+            setInventory(prevInventory => {
+              const nextInventory = { ...prevInventory };
+              Object.entries(producedGoods).forEach(([productKey, amount]) => {
+                nextInventory[productKey] = (nextInventory[productKey] || 0) + amount;
+              });
+              return nextInventory;
+            });
+
+            const produceSummary = Object.entries(producedGoods).map(([productKey, amount]) => {
+              const product = ANIMAL_PRODUCTS[productKey];
+              const label = product ? `${product.emoji} ${product.name}` : productKey;
+              return `${label} x${amount}`;
+            });
+
+            addNotification(`${produceSummary.join('、')} 入庫！可到庫存出售換現金。`, { type: 'info' });
+          }
 
           const infestedCrops = [];
           const destroyedCrops = [];
@@ -596,6 +654,18 @@ const FarmGame = () => {
 
   const waterPlot = useCallback((plotId) => {
     gameEngine.waterPlot(plotId);
+  }, [gameEngine]);
+
+  const expandFarmPlots = useCallback(() => {
+    gameEngine.expandFarm();
+  }, [gameEngine]);
+
+  const expandAnimalPens = useCallback(() => {
+    gameEngine.expandAnimalHousing();
+  }, [gameEngine]);
+
+  const sellInventoryItem = useCallback((itemKey) => {
+    gameEngine.sellInventoryItem(itemKey);
   }, [gameEngine]);
 
   const buyAnimal = useCallback((animalType) => {
@@ -812,6 +882,22 @@ const FarmGame = () => {
               ))}
             </div>
 
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-6 text-sm text-gray-700">
+              <div>
+                農地格數：{farmSize}/{MAX_FARM_PLOTS}
+              </div>
+              {nextFarmExpansionCost !== null ? (
+                <button
+                  onClick={expandFarmPlots}
+                  className="self-start sm:self-auto bg-green-500 hover:bg-green-600 text-white px-3 py-1 rounded transition-colors"
+                >
+                  擴建農地（{'$'}{nextFarmExpansionCost}）
+                </button>
+              ) : (
+                <span className="text-xs text-gray-500">農地已達最大規模</span>
+              )}
+            </div>
+
             {/* 建築展示 */}
             {Object.keys(buildings).length > 0 && (
               <div className="mt-4">
@@ -829,9 +915,21 @@ const FarmGame = () => {
             )}
 
             {/* 動物區域 */}
-            {animals.length > 0 && (
-              <div className="mt-6">
-                <h3 className="text-lg font-bold mb-3">我的動物們</h3>
+            <div className="mt-6">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-3">
+                <h3 className="text-lg font-bold">我的動物們（{animals.length}/{animalCapacity}）</h3>
+                {nextAnimalExpansionCost !== null ? (
+                  <button
+                    onClick={expandAnimalPens}
+                    className="self-start sm:self-auto bg-blue-500 hover:bg-blue-600 text-white px-3 py-1 rounded transition-colors"
+                  >
+                    擴建動物欄（{'$'}{nextAnimalExpansionCost}）
+                  </button>
+                ) : (
+                  <span className="text-xs text-gray-500">動物欄位已達上限</span>
+                )}
+              </div>
+              {animals.length > 0 ? (
                 <div className="grid grid-cols-4 gap-4">
                   {animals.map((animal) => {
                     const animalData = ANIMALS[animal.type];
@@ -880,9 +978,16 @@ const FarmGame = () => {
                                    style={{ width: `${Math.max(0, Math.min(100, hunger))}%` }}></div>
                             </div>
                           </div>
-                          <div className="text-xs text-green-600">
-                            日收入: ${Math.floor(animalData.income * (hasBuilding ? BUILDINGS[animalData.shelter].boost : 1))}
-                          </div>
+                          {animalData.product && ANIMAL_PRODUCTS[animalData.product] ? (
+                            <div className="text-xs text-amber-600">
+                              產物：{ANIMAL_PRODUCTS[animalData.product].emoji} {ANIMAL_PRODUCTS[animalData.product].name}
+                              <span className="ml-1 text-[10px] text-amber-500">（入庫可出售）</span>
+                            </div>
+                          ) : (
+                            <div className="text-xs text-green-600">
+                              日收入: ${Math.floor(animalData.income * (hasBuilding ? BUILDINGS[animalData.shelter].boost : 1))}
+                            </div>
+                          )}
                           <button
                             onClick={() => feedAnimal(animal.id)}
                             className={`w-full text-xs font-semibold py-1 rounded transition-colors ${
@@ -915,8 +1020,10 @@ const FarmGame = () => {
                     );
                   })}
                 </div>
-              </div>
-            )}
+              ) : (
+                <p className="text-sm text-gray-500">還沒有動物，快到動物商店迎接新成員吧！</p>
+              )}
+            </div>
           </div>
 
           {/* 側邊欄 */}
@@ -983,16 +1090,38 @@ const FarmGame = () => {
             {/* 庫存 */}
             <div className="bg-white bg-opacity-90 rounded-lg p-4 shadow-lg">
               <h3 className="text-lg font-bold mb-3">庫存</h3>
-              {Object.entries(inventory).map(([crop, count]) => (
-                count > 0 && (
-                  <div key={crop} className="flex justify-between items-center py-1">
-                    <span>{CROPS[crop].emoji} {CROPS[crop].name}</span>
-                    <span className="font-semibold">{count}</span>
+              {INVENTORY_ORDER.map((key) => {
+                const count = inventory[key] || 0;
+                if (count <= 0) {
+                  return null;
+                }
+
+                const item = INVENTORY_METADATA[key];
+                const saleValue = item.type === 'product' ? gameEngine.getInventorySaleValue(key, count) : 0;
+                const canSell = item.type === 'product' && saleValue > 0;
+
+                return (
+                  <div key={key} className="flex justify-between items-center py-1">
+                    <span>{item.emoji} {item.name}</span>
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">{count}</span>
+                      {canSell && (
+                        <button
+                          onClick={() => sellInventoryItem(key)}
+                          className="text-xs bg-amber-500 hover:bg-amber-600 text-white px-2 py-1 rounded transition-colors"
+                        >
+                          出售（{'$'}{saleValue}）
+                        </button>
+                      )}
+                    </div>
                   </div>
-                )
-              ))}
-              {Object.values(inventory).every(count => count === 0) && (
+                );
+              })}
+              {INVENTORY_ORDER.every(key => (inventory[key] || 0) === 0) && (
                 <p className="text-gray-500 text-sm">庫存為空</p>
+              )}
+              {Object.keys(ANIMAL_PRODUCTS).some(key => (inventory[key] || 0) > 0) && (
+                <p className="text-xs text-amber-600 mt-2">提示：雞蛋與鮮奶可在此處直接出售換現金！</p>
               )}
             </div>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,7 +31,9 @@ const FarmGame = () => {
       watered: false,
       fertilized: false,
       greenhouse: false,
-      pest: false
+      pest: false,
+      pestDays: 0,
+      ready: false,
     }))
   );
 
@@ -316,6 +318,12 @@ const FarmGame = () => {
             const newlySick = [];
             const sickAnimals = [];
             const updatedAnimals = [];
+            const newbornAnimals = [];
+            const typeCounts = prevAnimals.reduce((counts, current) => {
+              const type = current.type;
+              counts[type] = (counts[type] || 0) + 1;
+              return counts;
+            }, {});
 
             prevAnimals.forEach(animal => {
               const animalData = ANIMALS[animal.type];
@@ -361,6 +369,27 @@ const FarmGame = () => {
                 : 0;
               totalIncome += income;
 
+              if (!sick && hunger >= 75 && happiness >= 75 && newbornAnimals.length < 3) {
+                const birthChance = 0.12
+                  + (happiness > 90 ? 0.05 : 0)
+                  + (hunger > 90 ? 0.05 : 0);
+                if (Math.random() < birthChance) {
+                  typeCounts[animal.type] = (typeCounts[animal.type] || 0) + 1;
+                  const baseName = animalData.name;
+                  const babyIndex = typeCounts[animal.type];
+                  const babyName = `${baseName}寶寶${babyIndex}`;
+                  newbornAnimals.push({
+                    id: Date.now() + newbornAnimals.length + Math.floor(Math.random() * 1000),
+                    type: animal.type,
+                    happiness: animalData.happiness,
+                    hunger: 65,
+                    lastFed: Date.now(),
+                    sick: false,
+                    name: babyName,
+                  });
+                }
+              }
+
               updatedAnimals.push({
                 ...animal,
                 happiness,
@@ -394,25 +423,77 @@ const FarmGame = () => {
               addNotification(`💊 ${ongoingSick.join('、')} 仍在療養中，記得使用營養劑。`, { type: 'warning' });
             }
 
-            return updatedAnimals;
+            if (newbornAnimals.length > 0) {
+              const names = newbornAnimals.map(animal => animal.name).join('、');
+              addNotification(`🐣 ${names} 出生了，農場又更熱鬧了！`, { type: 'success' });
+            }
+
+            return [...updatedAnimals, ...newbornAnimals];
           });
 
           const infestedCrops = [];
+          const destroyedCrops = [];
+          const autoWatered = new Set();
           setFarm(prevFarm => {
             let changed = false;
+            const hasSprinkler = buildings?.sprinkler;
             const nextFarm = prevFarm.map(plot => {
               let updatedPlot = plot;
 
-              if (plot.crop && !plot.ready && !plot.pest) {
-                const pestChance = plot.fertilized ? 0.05 : 0.12;
-                if (Math.random() < pestChance) {
-                  infestedCrops.push(CROPS[plot.crop].name);
-                  updatedPlot = { ...plot, pest: true };
+              if (plot.crop) {
+                const originalCrop = CROPS[plot.crop];
+                if (!plot.ready && !plot.pest) {
+                  const pestChance = plot.fertilized ? 0.05 : 0.12;
+                  if (Math.random() < pestChance) {
+                    if (originalCrop) {
+                      infestedCrops.push(originalCrop.name);
+                    }
+                    updatedPlot = { ...plot, pest: true, pestDays: 1 };
+                  }
                 }
-              }
 
-              if (!updatedPlot.crop && updatedPlot.fertilized) {
-                updatedPlot = { ...updatedPlot, fertilized: false };
+                if (updatedPlot.pest) {
+                  const currentDays = updatedPlot.pestDays ?? 0;
+                  const nextDays = currentDays + (plot.pest ? 1 : 0);
+                  if (!updatedPlot.ready && nextDays >= 3) {
+                    const damagedCrop = updatedPlot.crop ? CROPS[updatedPlot.crop] : null;
+                    if (damagedCrop) {
+                      destroyedCrops.push(damagedCrop.name);
+                    }
+                    updatedPlot = {
+                      ...updatedPlot,
+                      crop: null,
+                      plantTime: null,
+                      watered: false,
+                      fertilized: false,
+                      pest: false,
+                      pestDays: 0,
+                      ready: false,
+                    };
+                  } else if (nextDays !== currentDays) {
+                    updatedPlot = { ...updatedPlot, pestDays: nextDays };
+                  }
+                } else if (updatedPlot.pestDays) {
+                  updatedPlot = { ...updatedPlot, pestDays: 0 };
+                }
+
+                if (hasSprinkler && updatedPlot.crop && !updatedPlot.ready && !updatedPlot.watered) {
+                  const cropInfo = CROPS[updatedPlot.crop];
+                  updatedPlot = { ...updatedPlot, watered: true };
+                  if (cropInfo) {
+                    autoWatered.add(cropInfo.name);
+                  }
+                }
+              } else {
+                if (updatedPlot.fertilized || updatedPlot.pest || (updatedPlot.pestDays ?? 0) > 0 || updatedPlot.ready) {
+                  updatedPlot = {
+                    ...updatedPlot,
+                    fertilized: false,
+                    pest: false,
+                    pestDays: 0,
+                    ready: false,
+                  };
+                }
               }
 
               if (updatedPlot !== plot) {
@@ -428,6 +509,16 @@ const FarmGame = () => {
           if (infestedCrops.length > 0) {
             const names = Array.from(new Set(infestedCrops)).join('、');
             addNotification(`🐛 害蟲入侵！${names} 需要使用驅蟲劑。`, { type: 'warning' });
+          }
+
+          if (destroyedCrops.length > 0) {
+            const names = Array.from(new Set(destroyedCrops)).join('、');
+            addNotification(`🥀 ${names} 因害蟲侵蝕而枯萎了……記得提早使用除蟲劑。`, { type: 'error' });
+          }
+
+          if (autoWatered.size > 0) {
+            const names = Array.from(autoWatered).join('、');
+            addNotification(`🚿 自動灑水器已為 ${names} 補足水分。`, { type: 'info' });
           }
 
           return 6;

--- a/src/FarmGame.jsx
+++ b/src/FarmGame.jsx
@@ -36,7 +36,7 @@ const BUILDINGS = {
   greenhouse:   { name: '溫室',      price: 2000, emoji: '🏢', description: '不受天氣影響的種植空間', boost: 1.5 },
   silo:         { name: '筒倉',      price: 800,  emoji: '🗼', description: '儲存更多作物',      boost: 1.0 },
   windmill:     { name: '風車',      price: 1500, emoji: '🌪️', description: '產生額外收入',      boost: 1.0 },
-  well:         { name: '水井',      price: 400,  emoji: '🕳️', description: '無限澆水，節省體力', boost: 1.0 },
+  sprinkler:    { name: '自動灑水器', price: 650,  emoji: '🚿', description: '每天自動澆灌作物，並降低澆水體力消耗', boost: 1.0 },
 }
 
 const WEATHER_TYPES = ['sunny', 'rainy', 'cloudy', 'storm', 'snow']
@@ -310,7 +310,7 @@ const FarmGame = () => {
   const plantSeed = (plotId) => {
     if (!selectedSeed) return
     if (seedBag[selectedSeed] <= 0) return addNotification('該種子庫存不足！')
-    const energyCost = buildings.well ? 5 : 10
+    const energyCost = buildings.sprinkler ? 5 : 10
     if (energy < energyCost) return addNotification('體力不足！')
 
     setFarm(prev => prev.map(p =>
@@ -361,7 +361,7 @@ const FarmGame = () => {
   }
 
   const waterPlot = (plotId) => {
-    const energyCost = buildings.well ? 2 : 5
+    const energyCost = buildings.sprinkler ? 1 : 5
     if (energy < energyCost) return addNotification('體力不足！')
     setFarm(prev => prev.map(p =>
       p.id === plotId && p.crop && !p.watered
@@ -393,8 +393,7 @@ const FarmGame = () => {
     setBuildings(b => ({ ...b, [buildingType]: true }))
 
     if (buildingType === 'greenhouse') {
-      // 前 5 格變成溫室地塊
-      setFarm(prev => prev.map((p, i) => i < 5 ? { ...p, greenhouse: true } : p))
+      setFarm(prev => prev.map(p => (p.greenhouse ? p : { ...p, greenhouse: true })))
     }
     setShowBuildingShop(false)
     addNotification(`建造了 ${BUILDINGS[buildingType].emoji} ${BUILDINGS[buildingType].name}！`)

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -47,12 +47,19 @@ class Building extends BaseEntity {
 }
 
 class Tool extends BaseEntity {
-  constructor(key, { name, energyReduction, speedBoost, price }) {
+  constructor(
+    key,
+    { name, energyReduction, speedBoost, price, upgradeCost = null, speedUpgrade = 0, energyUpgrade = 0, repeatableUpgrade = false }
+  ) {
     super(key);
     this.name = name;
     this.energyReduction = energyReduction;
     this.speedBoost = speedBoost;
     this.price = price;
+    this.upgradeCost = upgradeCost;
+    this.speedUpgrade = speedUpgrade;
+    this.energyUpgrade = energyUpgrade;
+    this.repeatableUpgrade = repeatableUpgrade;
   }
 }
 
@@ -286,9 +293,19 @@ class GameCatalog {
 
     this.tools = {
       basic: new Tool('basic', { name: '基本工具', energyReduction: 0, speedBoost: 1, price: 0 }),
-      iron: new Tool('iron', { name: '鐵製工具', energyReduction: 2, speedBoost: 1.2, price: 500 }),
-      steel: new Tool('steel', { name: '鋼製工具', energyReduction: 4, speedBoost: 1.5, price: 1200 }),
-      magic: new Tool('magic', { name: '魔法工具', energyReduction: 6, speedBoost: 2, price: 3000 }),
+      copper: new Tool('copper', { name: '銅製工具', energyReduction: 1, speedBoost: 1.15, price: 300 }),
+      iron: new Tool('iron', { name: '鐵製工具', energyReduction: 2, speedBoost: 1.3, price: 700 }),
+      steel: new Tool('steel', { name: '鋼製工具', energyReduction: 3, speedBoost: 1.45, price: 1200 }),
+      mithril: new Tool('mithril', { name: '秘銀工具', energyReduction: 4, speedBoost: 1.6, price: 1800 }),
+      magic: new Tool('magic', {
+        name: '魔法工具',
+        energyReduction: 5,
+        speedBoost: 1.75,
+        price: 2500,
+        upgradeCost: 2500,
+        speedUpgrade: 0.15,
+        repeatableUpgrade: true,
+      }),
     };
 
     this.animalProducts = {

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -72,6 +72,16 @@ class NPC {
   }
 }
 
+class Supply extends BaseEntity {
+  constructor(key, { name, price, emoji, description }) {
+    super(key);
+    this.name = name;
+    this.price = price;
+    this.emoji = emoji;
+    this.description = description;
+  }
+}
+
 class GameCatalog {
   constructor() {
     this.crops = {
@@ -106,6 +116,27 @@ class GameCatalog {
       silo: new Building('silo', { name: '筒倉', price: 800, emoji: '🗼', description: '儲存更多作物', boost: 1.0 }),
       windmill: new Building('windmill', { name: '風車', price: 1500, emoji: '🌪️', description: '產生額外收入', boost: 1.0 }),
       well: new Building('well', { name: '水井', price: 400, emoji: '🕳️', description: '無限澆水，節省體力', boost: 1.0 }),
+    };
+
+    this.supplies = {
+      fertilizer: new Supply('fertilizer', {
+        name: '有機肥料',
+        price: 45,
+        emoji: '🌿',
+        description: '提升土壤品質，縮短作物成熟時間。',
+      }),
+      pesticide: new Supply('pesticide', {
+        name: '天然驅蟲劑',
+        price: 30,
+        emoji: '🪲',
+        description: '清除害蟲，讓作物恢復生長。',
+      }),
+      medicine: new Supply('medicine', {
+        name: '動物營養劑',
+        price: 55,
+        emoji: '💊',
+        description: '治療生病的動物並恢復部分快樂度。',
+      }),
     };
 
     this.tools = {
@@ -155,6 +186,10 @@ class GameCatalog {
   getTool(key) {
     return this.tools[key];
   }
+
+  getSupply(key) {
+    return this.supplies[key];
+  }
 }
 
 export const WEATHER_TYPES = ['sunny', 'rainy', 'cloudy', 'storm', 'snow'];
@@ -165,6 +200,7 @@ export const CROPS = catalog.crops;
 export const ANIMALS = catalog.animals;
 export const BUILDINGS = catalog.buildings;
 export const TOOLS = catalog.tools;
+export const FARM_SUPPLIES = catalog.supplies;
 export const ACHIEVEMENTS = catalog.achievements;
 export const NPCS = catalog.npcs;
 

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -8,7 +8,7 @@ class BaseEntity {
 }
 
 class Crop extends BaseEntity {
-  constructor(key, { name, price, growTime, sellPrice, emoji, weatherBonus }) {
+  constructor(key, { name, price, growTime, sellPrice, emoji, weatherBonus, seasonBonus }) {
     super(key);
     this.name = name;
     this.price = price;
@@ -16,11 +16,12 @@ class Crop extends BaseEntity {
     this.sellPrice = sellPrice;
     this.emoji = emoji;
     this.weatherBonus = weatherBonus;
+    this.seasonBonus = seasonBonus || {};
   }
 }
 
 class Animal extends BaseEntity {
-  constructor(key, { name, price, happiness, emoji, foodCost, income, shelter, product }) {
+  constructor(key, { name, price, happiness, emoji, foodCost, income, shelter, product, butcher }) {
     super(key);
     this.name = name;
     this.price = price;
@@ -30,6 +31,7 @@ class Animal extends BaseEntity {
     this.income = income;
     this.shelter = shelter;
     this.product = product;
+    this.butcher = butcher;
   }
 }
 
@@ -86,23 +88,100 @@ class Supply extends BaseEntity {
 class GameCatalog {
   constructor() {
     this.crops = {
-      carrot: new Crop('carrot', { name: '胡蘿蔔', price: 10, growTime: 5, sellPrice: 25, emoji: '🥕', weatherBonus: { sunny: 1.2, rainy: 1.0, snow: 0.8 } }),
-      corn: new Crop('corn', { name: '玉米', price: 20, growTime: 8, sellPrice: 50, emoji: '🌽', weatherBonus: { sunny: 1.3, rainy: 1.1, snow: 0.6 } }),
-      tomato: new Crop('tomato', { name: '番茄', price: 15, growTime: 6, sellPrice: 35, emoji: '🍅', weatherBonus: { sunny: 1.4, rainy: 0.9, snow: 0.5 } }),
-      wheat: new Crop('wheat', { name: '小麥', price: 8, growTime: 4, sellPrice: 20, emoji: '🌾', weatherBonus: { sunny: 1.1, rainy: 1.2, snow: 0.9 } }),
-      potato: new Crop('potato', { name: '馬鈴薯', price: 12, growTime: 7, sellPrice: 30, emoji: '🥔', weatherBonus: { sunny: 1.0, rainy: 1.3, snow: 1.1 } }),
-      strawberry: new Crop('strawberry', { name: '草莓', price: 25, growTime: 10, sellPrice: 60, emoji: '🍓', weatherBonus: { sunny: 1.2, rainy: 0.8, snow: 0.4 } }),
+      carrot: new Crop('carrot', {
+        name: '胡蘿蔔',
+        price: 10,
+        growTime: 5,
+        sellPrice: 25,
+        emoji: '🥕',
+        weatherBonus: { sunny: 1.2, rainy: 1.0, snow: 0.8 },
+        seasonBonus: { spring: 1.15, summer: 0.9, autumn: 1.2, winter: 0.7 },
+      }),
+      corn: new Crop('corn', {
+        name: '玉米',
+        price: 20,
+        growTime: 8,
+        sellPrice: 50,
+        emoji: '🌽',
+        weatherBonus: { sunny: 1.3, rainy: 1.1, snow: 0.6 },
+        seasonBonus: { spring: 0.85, summer: 1.25, autumn: 1.05, winter: 0.55 },
+      }),
+      tomato: new Crop('tomato', {
+        name: '番茄',
+        price: 15,
+        growTime: 6,
+        sellPrice: 35,
+        emoji: '🍅',
+        weatherBonus: { sunny: 1.4, rainy: 0.9, snow: 0.5 },
+        seasonBonus: { spring: 1.0, summer: 1.3, autumn: 0.85, winter: 0.5 },
+      }),
+      wheat: new Crop('wheat', {
+        name: '小麥',
+        price: 8,
+        growTime: 4,
+        sellPrice: 20,
+        emoji: '🌾',
+        weatherBonus: { sunny: 1.1, rainy: 1.2, snow: 0.9 },
+        seasonBonus: { spring: 1.05, summer: 1.1, autumn: 1.25, winter: 0.85 },
+      }),
+      potato: new Crop('potato', {
+        name: '馬鈴薯',
+        price: 12,
+        growTime: 7,
+        sellPrice: 30,
+        emoji: '🥔',
+        weatherBonus: { sunny: 1.0, rainy: 1.3, snow: 1.1 },
+        seasonBonus: { spring: 0.95, summer: 1.1, autumn: 1.35, winter: 0.95 },
+      }),
+      strawberry: new Crop('strawberry', {
+        name: '草莓',
+        price: 25,
+        growTime: 10,
+        sellPrice: 60,
+        emoji: '🍓',
+        weatherBonus: { sunny: 1.2, rainy: 0.8, snow: 0.4 },
+        seasonBonus: { spring: 1.35, summer: 1.1, autumn: 0.75, winter: 0.4 },
+      }),
     };
 
     this.animals = {
-      dog: new Animal('dog', { name: '狗狗', price: 200, happiness: 50, emoji: '🐕', foodCost: 5, income: 8, shelter: 'dogHouse' }),
-      cat: new Animal('cat', { name: '貓咪', price: 150, happiness: 60, emoji: '🐱', foodCost: 3, income: 5, shelter: 'catHouse' }),
-      chicken: new Animal('chicken', { name: '雞', price: 100, happiness: 40, emoji: '🐔', foodCost: 2, income: 12, shelter: 'chickenCoop', product: 'egg' }),
-      cow: new Animal('cow', { name: '牛', price: 500, happiness: 30, emoji: '🐄', foodCost: 10, income: 25, shelter: 'barn', product: 'milk' }),
-      pig: new Animal('pig', { name: '豬', price: 300, happiness: 45, emoji: '🐷', foodCost: 8, income: 18, shelter: 'pigPen' }),
-      sheep: new Animal('sheep', { name: '羊', price: 250, happiness: 40, emoji: '🐑', foodCost: 6, income: 15, shelter: 'barn' }),
-      duck: new Animal('duck', { name: '鴨子', price: 120, happiness: 55, emoji: '🦆', foodCost: 3, income: 10, shelter: 'pond' }),
-      rabbit: new Animal('rabbit', { name: '兔子', price: 80, happiness: 70, emoji: '🐰', foodCost: 2, income: 6, shelter: 'rabbitHutch' }),
+      dog: new Animal('dog', { name: '狗狗', price: 200, happiness: 50, emoji: '🐕', foodCost: 5, income: 10, shelter: 'dogHouse' }),
+      cat: new Animal('cat', { name: '貓咪', price: 150, happiness: 60, emoji: '🐱', foodCost: 3, income: 7, shelter: 'catHouse' }),
+      chicken: new Animal('chicken', {
+        name: '雞',
+        price: 100,
+        happiness: 40,
+        emoji: '🐔',
+        foodCost: 2,
+        income: 18,
+        shelter: 'chickenCoop',
+        product: 'egg',
+        butcher: { product: 'chickenMeat', amount: 1 },
+      }),
+      cow: new Animal('cow', {
+        name: '牛',
+        price: 500,
+        happiness: 30,
+        emoji: '🐄',
+        foodCost: 10,
+        income: 40,
+        shelter: 'barn',
+        product: 'milk',
+        butcher: { product: 'beef', amount: 1 },
+      }),
+      pig: new Animal('pig', {
+        name: '豬',
+        price: 300,
+        happiness: 45,
+        emoji: '🐷',
+        foodCost: 8,
+        income: 30,
+        shelter: 'pigPen',
+        butcher: { product: 'pork', amount: 1 },
+      }),
+      sheep: new Animal('sheep', { name: '羊', price: 250, happiness: 40, emoji: '🐑', foodCost: 6, income: 18, shelter: 'barn' }),
+      duck: new Animal('duck', { name: '鴨子', price: 120, happiness: 55, emoji: '🦆', foodCost: 3, income: 14, shelter: 'pond' }),
+      rabbit: new Animal('rabbit', { name: '兔子', price: 80, happiness: 70, emoji: '🐰', foodCost: 2, income: 8, shelter: 'rabbitHutch' }),
     };
 
     this.buildings = {
@@ -148,8 +227,11 @@ class GameCatalog {
     };
 
     this.animalProducts = {
-      egg: { key: 'egg', name: '雞蛋', emoji: '🥚', basePrice: 10, animal: 'chicken' },
-      milk: { key: 'milk', name: '鮮奶', emoji: '🥛', basePrice: 20, animal: 'cow' },
+      egg: { key: 'egg', name: '雞蛋', emoji: '🥚', basePrice: 14, animal: 'chicken' },
+      milk: { key: 'milk', name: '鮮奶', emoji: '🥛', basePrice: 35, animal: 'cow' },
+      chickenMeat: { key: 'chickenMeat', name: '雞肉', emoji: '🍗', basePrice: 95, animal: 'chicken' },
+      beef: { key: 'beef', name: '牛肉', emoji: '🥩', basePrice: 220, animal: 'cow' },
+      pork: { key: 'pork', name: '豬肉', emoji: '🍖', basePrice: 160, animal: 'pig' },
     };
 
     this.achievements = [

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -115,7 +115,7 @@ class GameCatalog {
       greenhouse: new Building('greenhouse', { name: '溫室', price: 2000, emoji: '🏢', description: '不受天氣影響的種植空間', boost: 1.5 }),
       silo: new Building('silo', { name: '筒倉', price: 800, emoji: '🗼', description: '儲存更多作物', boost: 1.0 }),
       windmill: new Building('windmill', { name: '風車', price: 1500, emoji: '🌪️', description: '產生額外收入', boost: 1.0 }),
-      well: new Building('well', { name: '水井', price: 400, emoji: '🕳️', description: '無限澆水，節省體力', boost: 1.0 }),
+      sprinkler: new Building('sprinkler', { name: '自動灑水器', price: 650, emoji: '🚿', description: '每天早晨自動澆灌所有作物並減少澆水體力消耗', boost: 1.0 }),
     };
 
     this.supplies = {

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -20,7 +20,7 @@ class Crop extends BaseEntity {
 }
 
 class Animal extends BaseEntity {
-  constructor(key, { name, price, happiness, emoji, foodCost, income, shelter }) {
+  constructor(key, { name, price, happiness, emoji, foodCost, income, shelter, product }) {
     super(key);
     this.name = name;
     this.price = price;
@@ -29,6 +29,7 @@ class Animal extends BaseEntity {
     this.foodCost = foodCost;
     this.income = income;
     this.shelter = shelter;
+    this.product = product;
   }
 }
 
@@ -96,8 +97,8 @@ class GameCatalog {
     this.animals = {
       dog: new Animal('dog', { name: '狗狗', price: 200, happiness: 50, emoji: '🐕', foodCost: 5, income: 8, shelter: 'dogHouse' }),
       cat: new Animal('cat', { name: '貓咪', price: 150, happiness: 60, emoji: '🐱', foodCost: 3, income: 5, shelter: 'catHouse' }),
-      chicken: new Animal('chicken', { name: '雞', price: 100, happiness: 40, emoji: '🐔', foodCost: 2, income: 12, shelter: 'chickenCoop' }),
-      cow: new Animal('cow', { name: '牛', price: 500, happiness: 30, emoji: '🐄', foodCost: 10, income: 25, shelter: 'barn' }),
+      chicken: new Animal('chicken', { name: '雞', price: 100, happiness: 40, emoji: '🐔', foodCost: 2, income: 12, shelter: 'chickenCoop', product: 'egg' }),
+      cow: new Animal('cow', { name: '牛', price: 500, happiness: 30, emoji: '🐄', foodCost: 10, income: 25, shelter: 'barn', product: 'milk' }),
       pig: new Animal('pig', { name: '豬', price: 300, happiness: 45, emoji: '🐷', foodCost: 8, income: 18, shelter: 'pigPen' }),
       sheep: new Animal('sheep', { name: '羊', price: 250, happiness: 40, emoji: '🐑', foodCost: 6, income: 15, shelter: 'barn' }),
       duck: new Animal('duck', { name: '鴨子', price: 120, happiness: 55, emoji: '🦆', foodCost: 3, income: 10, shelter: 'pond' }),
@@ -146,6 +147,11 @@ class GameCatalog {
       magic: new Tool('magic', { name: '魔法工具', energyReduction: 6, speedBoost: 2, price: 3000 }),
     };
 
+    this.animalProducts = {
+      egg: { key: 'egg', name: '雞蛋', emoji: '🥚', basePrice: 10, animal: 'chicken' },
+      milk: { key: 'milk', name: '鮮奶', emoji: '🥛', basePrice: 20, animal: 'cow' },
+    };
+
     this.achievements = [
       new Achievement({ id: 'firstPlant', name: '初次種植', description: '種下第一株作物', reward: 100, icon: '🌱' }),
       new Achievement({ id: 'richFarmer', name: '富豪農夫', description: '擁有10000金幣', reward: 500, icon: '💰' }),
@@ -190,6 +196,10 @@ class GameCatalog {
   getSupply(key) {
     return this.supplies[key];
   }
+
+  getAnimalProduct(key) {
+    return this.animalProducts[key];
+  }
 }
 
 export const WEATHER_TYPES = ['sunny', 'rainy', 'cloudy', 'storm', 'snow'];
@@ -198,6 +208,7 @@ export const SEASONS = ['spring', 'summer', 'autumn', 'winter'];
 export const catalog = new GameCatalog();
 export const CROPS = catalog.crops;
 export const ANIMALS = catalog.animals;
+export const ANIMAL_PRODUCTS = catalog.animalProducts;
 export const BUILDINGS = catalog.buildings;
 export const TOOLS = catalog.tools;
 export const FARM_SUPPLIES = catalog.supplies;

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -166,13 +166,46 @@ class GameCatalog {
         name: '農夫老張',
         emoji: '👨‍🌾',
         dialogue: ['今天天氣真好呢！', '記得給作物澆水哦！', '我這裡有些好種子...'],
-        quests: [{ type: 'plant', target: 'carrot', count: 5, reward: 200 }],
+        quests: [
+          {
+            id: 'farmer_wheat_bundle',
+            type: 'deliver',
+            target: 'wheat',
+            count: 30,
+            reward: 480,
+            description: '收穫祭要到了，老張需要 30 束小麥來布置穀倉。',
+          },
+          {
+            id: 'farmer_pest_control',
+            type: 'pestClear',
+            count: 3,
+            reward: 260,
+            description: '最近害蟲肆虐，幫忙處理 3 塊農地的蟲害吧。',
+          },
+        ],
       }),
       new NPC({
         name: '商人小李',
         emoji: '👨‍💼',
         dialogue: ['生意興隆！', '需要什麼嗎？', '我有特價商品！'],
-        quests: [{ type: 'sell', target: 'tomato', count: 10, reward: 300 }],
+        quests: [
+          {
+            id: 'merchant_carrot_bulk',
+            type: 'deliver',
+            target: 'carrot',
+            count: 50,
+            reward: 1500,
+            description: '小李接到外地大單，需要 50 根胡蘿蔔立即出貨。',
+          },
+          {
+            id: 'merchant_sweet_wave',
+            type: 'sell',
+            target: 'strawberry',
+            count: 25,
+            reward: 620,
+            description: '市場草莓熱潮來了！賣出 25 盒草莓即可分紅。',
+          },
+        ],
       }),
     ];
   }

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -142,6 +142,51 @@ class GameCatalog {
         weatherBonus: { sunny: 1.2, rainy: 0.8, snow: 0.4 },
         seasonBonus: { spring: 1.35, summer: 1.1, autumn: 0.75, winter: 0.4 },
       }),
+      blueberry: new Crop('blueberry', {
+        name: '藍莓',
+        price: 28,
+        growTime: 9,
+        sellPrice: 70,
+        emoji: '🫐',
+        weatherBonus: { sunny: 1.1, rainy: 1.2, snow: 0.5 },
+        seasonBonus: { spring: 1.2, summer: 1.35, autumn: 0.8, winter: 0.45 },
+      }),
+      pumpkin: new Crop('pumpkin', {
+        name: '南瓜',
+        price: 32,
+        growTime: 12,
+        sellPrice: 95,
+        emoji: '🎃',
+        weatherBonus: { sunny: 1.25, rainy: 0.95, snow: 0.4 },
+        seasonBonus: { spring: 0.85, summer: 1.05, autumn: 1.4, winter: 0.4 },
+      }),
+      soybean: new Crop('soybean', {
+        name: '黃豆',
+        price: 18,
+        growTime: 7,
+        sellPrice: 45,
+        emoji: '🫘',
+        weatherBonus: { sunny: 1.15, rainy: 1.25, snow: 0.7 },
+        seasonBonus: { spring: 1.05, summer: 1.25, autumn: 1.1, winter: 0.65 },
+      }),
+      rice: new Crop('rice', {
+        name: '水稻',
+        price: 22,
+        growTime: 11,
+        sellPrice: 65,
+        emoji: '🍚',
+        weatherBonus: { sunny: 0.9, rainy: 1.4, snow: 0.5 },
+        seasonBonus: { spring: 1.0, summer: 1.35, autumn: 1.1, winter: 0.5 },
+      }),
+      tea: new Crop('tea', {
+        name: '茶葉',
+        price: 30,
+        growTime: 13,
+        sellPrice: 105,
+        emoji: '🍃',
+        weatherBonus: { sunny: 1.3, rainy: 1.0, snow: 0.6 },
+        seasonBonus: { spring: 1.4, summer: 1.1, autumn: 0.95, winter: 0.55 },
+      }),
     };
 
     this.animals = {
@@ -179,23 +224,43 @@ class GameCatalog {
         shelter: 'pigPen',
         butcher: { product: 'pork', amount: 1 },
       }),
-      sheep: new Animal('sheep', { name: '羊', price: 250, happiness: 40, emoji: '🐑', foodCost: 6, income: 18, shelter: 'barn' }),
-      duck: new Animal('duck', { name: '鴨子', price: 120, happiness: 55, emoji: '🦆', foodCost: 3, income: 14, shelter: 'pond' }),
+      sheep: new Animal('sheep', {
+        name: '羊',
+        price: 250,
+        happiness: 40,
+        emoji: '🐑',
+        foodCost: 6,
+        income: 18,
+        shelter: 'barn',
+        product: 'wool',
+        butcher: { product: 'mutton', amount: 1 },
+      }),
+      duck: new Animal('duck', {
+        name: '鴨子',
+        price: 120,
+        happiness: 55,
+        emoji: '🦆',
+        foodCost: 3,
+        income: 14,
+        shelter: 'pond',
+        product: 'duckEgg',
+        butcher: { product: 'duckMeat', amount: 1 },
+      }),
       rabbit: new Animal('rabbit', { name: '兔子', price: 80, happiness: 70, emoji: '🐰', foodCost: 2, income: 8, shelter: 'rabbitHutch' }),
     };
 
     this.buildings = {
-      barn: new Building('barn', { name: '穀倉', price: 1000, emoji: '🏚️', description: '容納牛羊，提升產量', boost: 1.2 }),
-      chickenCoop: new Building('chickenCoop', { name: '雞舍', price: 500, emoji: '🏠', description: '專門養雞，提升產蛋率', boost: 1.3 }),
+      barn: new Building('barn', { name: '穀倉', price: 1000, emoji: '🏚️', description: '容納牛羊，提升產量（可升級）', boost: 1.2 }),
+      chickenCoop: new Building('chickenCoop', { name: '雞舍', price: 500, emoji: '🏠', description: '專門養雞，提升產蛋率（可升級）', boost: 1.3 }),
       dogHouse: new Building('dogHouse', { name: '狗屋', price: 300, emoji: '🏘️', description: '狗狗的溫馨小窩', boost: 1.1 }),
       catHouse: new Building('catHouse', { name: '貓屋', price: 250, emoji: '🏡', description: '貓咪的舒適居所', boost: 1.1 }),
-      pigPen: new Building('pigPen', { name: '豬圈', price: 400, emoji: '🏗️', description: '豬豬的泥土樂園', boost: 1.2 }),
-      pond: new Building('pond', { name: '池塘', price: 600, emoji: '🌊', description: '水鳥的天堂', boost: 1.3 }),
+      pigPen: new Building('pigPen', { name: '豬圈', price: 400, emoji: '🏗️', description: '豬豬的泥土樂園（可升級）', boost: 1.2 }),
+      pond: new Building('pond', { name: '池塘', price: 600, emoji: '🌊', description: '水鳥的天堂（可升級）', boost: 1.3 }),
       rabbitHutch: new Building('rabbitHutch', { name: '兔籠', price: 200, emoji: '📦', description: '兔子的安全小屋', boost: 1.2 }),
       greenhouse: new Building('greenhouse', { name: '溫室', price: 2000, emoji: '🏢', description: '不受天氣影響的種植空間', boost: 1.5 }),
-      silo: new Building('silo', { name: '筒倉', price: 800, emoji: '🗼', description: '儲存更多作物', boost: 1.0 }),
+      silo: new Building('silo', { name: '筒倉', price: 800, emoji: '🗼', description: '提升作物保存品質（可升級）', boost: 1.0 }),
       windmill: new Building('windmill', { name: '風車', price: 1500, emoji: '🌪️', description: '產生額外收入', boost: 1.0 }),
-      sprinkler: new Building('sprinkler', { name: '自動灑水器', price: 650, emoji: '🚿', description: '每天早晨自動澆灌所有作物並減少澆水體力消耗', boost: 1.0 }),
+      sprinkler: new Building('sprinkler', { name: '自動灑水器', price: 650, emoji: '🚿', description: '每天早晨自動灌溉部分農地，升級可覆蓋整個農場', boost: 1.0 }),
     };
 
     this.supplies = {
@@ -229,9 +294,13 @@ class GameCatalog {
     this.animalProducts = {
       egg: { key: 'egg', name: '雞蛋', emoji: '🥚', basePrice: 14, animal: 'chicken' },
       milk: { key: 'milk', name: '鮮奶', emoji: '🥛', basePrice: 35, animal: 'cow' },
+      duckEgg: { key: 'duckEgg', name: '鴨蛋', emoji: '🥚', basePrice: 18, animal: 'duck' },
+      wool: { key: 'wool', name: '羊毛', emoji: '🧶', basePrice: 48, animal: 'sheep' },
       chickenMeat: { key: 'chickenMeat', name: '雞肉', emoji: '🍗', basePrice: 95, animal: 'chicken' },
       beef: { key: 'beef', name: '牛肉', emoji: '🥩', basePrice: 220, animal: 'cow' },
       pork: { key: 'pork', name: '豬肉', emoji: '🍖', basePrice: 160, animal: 'pig' },
+      duckMeat: { key: 'duckMeat', name: '鴨肉', emoji: '🦆', basePrice: 130, animal: 'duck' },
+      mutton: { key: 'mutton', name: '羊肉', emoji: '🍖', basePrice: 150, animal: 'sheep' },
     };
 
     this.achievements = [

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -134,7 +134,7 @@ export class GameEngine {
 
       this.setters.setFarm(prev => prev.map(p => (
         p.id === plotId
-          ? { ...p, pest: false }
+          ? { ...p, pest: false, pestDays: 0 }
           : p
       )));
       this.consumeSupply('pesticide', { keepSelection: available > 1 });
@@ -155,7 +155,7 @@ export class GameEngine {
       return;
     }
 
-    const energyCost = Math.max(1, 10 - TOOLS[tools].energyReduction - (buildings?.well ? 5 : 0));
+    const energyCost = Math.max(1, 10 - TOOLS[tools].energyReduction - (buildings?.sprinkler ? 5 : 0));
     if (energy < energyCost) {
       this.notify('體力不足！', { type: 'warning' });
       return;
@@ -165,7 +165,7 @@ export class GameEngine {
     this.setters.setFarm(prev => prev.map(plot => {
       if (plot.id === plotId && !plot.crop) {
         planted = true;
-        return { ...plot, crop: selectedSeed, plantTime: Date.now(), watered: false, ready: false, pest: false };
+        return { ...plot, crop: selectedSeed, plantTime: Date.now(), watered: false, ready: false, pest: false, pestDays: 0 };
       }
       return plot;
     }));
@@ -203,7 +203,7 @@ export class GameEngine {
     this.setters.setExperience(prev => prev + 10);
     this.setters.setFarm(prev => prev.map(p =>
       p.id === plotId
-        ? { ...p, crop: null, plantTime: null, watered: false, ready: false, pest: false, fertilized: false }
+        ? { ...p, crop: null, plantTime: null, watered: false, ready: false, pest: false, pestDays: 0, fertilized: false }
         : p
     ));
 
@@ -212,7 +212,7 @@ export class GameEngine {
 
   waterPlot(plotId) {
     const { energy, buildings } = this.state;
-    const energyCost = buildings?.well ? 2 : 5;
+    const energyCost = buildings?.sprinkler ? 1 : 5;
     if (energy < energyCost) {
       this.notify('體力不足，無法澆水！', { type: 'warning' });
       return;
@@ -271,9 +271,9 @@ export class GameEngine {
       this.setters.setBuildings(prev => ({ ...prev, [buildingType]: true }));
 
       if (buildingType === 'greenhouse') {
-        this.setters.setFarm(prev => prev.map((plot, index) =>
-          index < 5 ? { ...plot, greenhouse: true } : plot
-        ));
+        this.setters.setFarm(prev => prev.map(plot => (
+          plot.greenhouse ? plot : { ...plot, greenhouse: true }
+        )));
       }
 
       this.setters.setShowBuildingShop(false);

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -260,7 +260,9 @@ export class GameEngine {
       ...prev,
       [seedKey]: (prev?.[seedKey] || 0) + amount,
     }));
-    this.notify(`購買了 ${amount} 包${crop.name}種子，已存入倉庫。`, { type: 'success' });
+    this.setters.setSelectedSupply(null);
+    this.setters.setSelectedSeed(seedType);
+    this.notify(`購買了 ${amount} 包${crop.name}種子，已存入倉庫並可直接種植。`, { type: 'success' });
   }
 
   buySeed(seedType, options) {
@@ -271,23 +273,24 @@ export class GameEngine {
     }
   }
 
-  buySupply(supplyType) {
+  buySupply(supplyType, options = {}) {
     const supply = FARM_SUPPLIES[supplyType];
     if (!supply) return;
 
+    const quantity = Math.max(1, Math.floor(options.quantity ?? 1));
+    const totalCost = supply.price * quantity;
     const { money } = this.state;
-    if (money < supply.price) {
+    if (money < totalCost) {
       this.notify('金錢不足，無法購買！', { type: 'error' });
       return;
     }
 
-    this.setters.setMoney(prev => prev - supply.price);
+    this.setters.setMoney(prev => prev - totalCost);
     this.setters.setFarmSupplies(prev => {
       const previous = prev || {};
-      return { ...previous, [supplyType]: (previous[supplyType] || 0) + 1 };
+      return { ...previous, [supplyType]: (previous[supplyType] || 0) + quantity };
     });
-    this.setters.setShowSupplyShop(false);
-    this.notify(`購買了 ${supply.emoji} ${supply.name}！`, { type: 'success' });
+    this.notify(`購買了 ${quantity} 份${supply.name}！`, { type: 'success' });
   }
 
   expandFarm() {
@@ -498,18 +501,30 @@ export class GameEngine {
       return;
     }
 
+    let remainingSeeds = storedSeeds;
+    let remainingMoney = money;
     if (usingStoredSeed) {
+      remainingSeeds = storedSeeds - 1;
       this.setters.setInventory(prev => ({
         ...prev,
         [seedKey]: Math.max(0, (prev?.[seedKey] || 0) - 1),
       }));
     } else {
+      remainingMoney = money - price;
       this.setters.setMoney(prev => prev - price);
     }
 
     this.setters.setEnergy(prev => Math.max(0, prev - energyCost));
     this.setters.setExperience(prev => prev + 5);
-    this.setters.setSelectedSeed(null);
+
+    const canContinuePlanting = usingStoredSeed
+      ? remainingSeeds > 0
+      : remainingMoney >= price;
+
+    if (!canContinuePlanting) {
+      this.setters.setSelectedSeed(null);
+    }
+
     this.setters.setSelectedSupply(null);
     const crop = CROPS[selectedSeed];
     if (crop?.seasonBonus) {
@@ -546,7 +561,6 @@ export class GameEngine {
 
     const sellPrice = Math.floor(basePrice * bonus);
 
-    this.setters.setMoney(prev => prev + sellPrice);
     this.setters.setInventory(prev => ({
       ...prev,
       [crop]: ((prev && prev[crop]) || 0) + 1,
@@ -567,7 +581,7 @@ export class GameEngine {
         : p
     )));
 
-    this.notify(`收成了 ${CROPS[crop].emoji}！獲得 $${sellPrice}`, { type: 'success' });
+    this.notify(`收成了 ${CROPS[crop].emoji}！已存入倉庫（估值 $${sellPrice}）。`, { type: 'success' });
     this.emitQuestEvent({ type: 'harvest', crop, amount: 1 });
   }
 
@@ -589,7 +603,7 @@ export class GameEngine {
     this.notify('澆水完成！', { type: 'success' });
   }
 
-  buyAnimal(animalType) {
+  buyAnimal(animalType, options = {}) {
     const { money, animals = [], animalCapacity } = this.state;
     const animal = ANIMALS[animalType];
     const requiredShelter = animal.shelter;
@@ -601,27 +615,41 @@ export class GameEngine {
     }
 
     const capacityLimit = Math.max(animalCapacity || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY);
-    if ((animals?.length || 0) >= capacityLimit) {
+    const existingCount = animals?.length || 0;
+    const availableSlots = Math.max(0, capacityLimit - existingCount);
+    if (availableSlots <= 0) {
       this.notify('動物欄位已滿，請先擴建或整理空間。', { type: 'warning' });
       return;
     }
 
-    if (money >= animal.price) {
-      this.setters.setMoney(prev => prev - animal.price);
-      this.setters.setAnimals(prev => [...prev, {
-        id: Date.now(),
+    const requestedQuantity = Math.max(1, Math.floor(options.quantity ?? 1));
+    const affordable = Math.floor(money / animal.price);
+    const purchasable = Math.min(requestedQuantity, availableSlots, affordable);
+
+    if (purchasable <= 0) {
+      this.notify('金錢不足，無法購買！', { type: 'error' });
+      return;
+    }
+
+    this.setters.setMoney(prev => prev - (animal.price * purchasable));
+    this.setters.setAnimals(prev => {
+      const prevList = Array.isArray(prev) ? prev : [];
+      const baseIndex = prevList.filter(a => a.type === animalType).length;
+      const timestamp = Date.now();
+      const additions = Array.from({ length: purchasable }, (_, index) => ({
+        id: timestamp + index,
         type: animalType,
         happiness: animal.happiness,
         hunger: 70,
         lastFed: Date.now(),
         sick: false,
-        name: `${animal.name}${prev.filter(a => a.type === animalType).length + 1}`,
-      }]);
-      this.setters.setShowAnimalShop(false);
-      this.notify(`購買了 ${animal.emoji} ${animal.name}！`, { type: 'success' });
-    } else {
-      this.notify('金錢不足！', { type: 'error' });
-    }
+        name: `${animal.name}${baseIndex + index + 1}`,
+      }));
+      return [...prevList, ...additions];
+    });
+
+    const label = purchasable > 1 ? `${purchasable} 隻${animal.name}` : `${animal.name}`;
+    this.notify(`購買了 ${animal.emoji} ${label}！`, { type: 'success' });
   }
 
   slaughterAnimal(animalId) {

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -4,17 +4,21 @@ export const BASE_FARM_PLOTS = 25;
 export const FARM_EXPANSION_BATCH = 5;
 export const MAX_FARM_PLOTS = 45;
 export const BASE_ANIMAL_CAPACITY = 6;
-export const ANIMAL_CAPACITY_STEP = 3;
+export const ANIMAL_CAPACITY_STEP = 1;
 export const MAX_ANIMAL_CAPACITY = 24;
 
 export const getFarmExpansionCost = (currentPlotCount) => {
-  const purchasedBatches = Math.max(0, Math.floor((currentPlotCount - BASE_FARM_PLOTS) / FARM_EXPANSION_BATCH));
-  return 500 + purchasedBatches * 200;
+  if (currentPlotCount >= MAX_FARM_PLOTS) {
+    return null;
+  }
+  return 5000;
 };
 
 export const getAnimalHousingExpansionCost = (currentCapacity) => {
-  const purchasedSteps = Math.max(0, Math.floor((currentCapacity - BASE_ANIMAL_CAPACITY) / ANIMAL_CAPACITY_STEP));
-  return 650 + purchasedSteps * 250;
+  if (currentCapacity >= MAX_ANIMAL_CAPACITY) {
+    return null;
+  }
+  return 2500;
 };
 
 export class GameEngine {
@@ -31,6 +35,12 @@ export class GameEngine {
   notify(message, options) {
     if (this.notifier) {
       this.notifier(message, options);
+    }
+  }
+
+  emitQuestEvent(event) {
+    if (typeof this.setters.recordQuestEvent === 'function') {
+      this.setters.recordQuestEvent(event);
     }
   }
 
@@ -109,6 +119,10 @@ export class GameEngine {
     }
 
     const price = getFarmExpansionCost(farm.length);
+    if (price == null) {
+      this.notify('農地目前無法擴建。', { type: 'info' });
+      return;
+    }
     if (money < price) {
       this.notify('金錢不足，暫時無法擴建農地。', { type: 'error' });
       return;
@@ -151,6 +165,10 @@ export class GameEngine {
     }
 
     const price = getAnimalHousingExpansionCost(currentCapacity);
+    if (price == null) {
+      this.notify('暫時無法擴建動物欄。', { type: 'info' });
+      return;
+    }
     if (money < price) {
       this.notify('金錢不足，暫時無法擴建動物欄。', { type: 'error' });
       return;
@@ -246,6 +264,7 @@ export class GameEngine {
       )));
       this.consumeSupply('pesticide', { keepSelection: available > 1 });
       this.notify('成功清除害蟲，作物恢復生長！', { type: 'success' });
+      this.emitQuestEvent({ type: 'pestClear', amount: 1 });
       return true;
     }
 
@@ -327,6 +346,7 @@ export class GameEngine {
     )));
 
     this.notify(`收成了 ${CROPS[crop].emoji}！獲得 $${sellPrice}`, { type: 'success' });
+    this.emitQuestEvent({ type: 'harvest', crop, amount: 1 });
   }
 
   waterPlot(plotId) {
@@ -574,6 +594,10 @@ export class GameEngine {
       this.notify(`出售了 ${amountToSell} 份${CROPS[itemKey].name}，獲得 $${saleValue}！`, { type: 'success' });
     } else {
       this.notify(`出售物品獲得 $${saleValue}！`, { type: 'success' });
+    }
+
+    if (CROPS[itemKey]) {
+      this.emitQuestEvent({ type: 'sell', crop: itemKey, amount: amountToSell });
     }
   }
 

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -1,4 +1,4 @@
-import { CROPS, ANIMALS, BUILDINGS, TOOLS } from '../data/GameCatalog';
+import { CROPS, ANIMALS, BUILDINGS, TOOLS, FARM_SUPPLIES } from '../data/GameCatalog';
 
 export class GameEngine {
   constructor({ stateRef, setters, notifier }) {
@@ -17,23 +17,143 @@ export class GameEngine {
     }
   }
 
+  consumeSupply(supplyType, { keepSelection = false } = {}) {
+    this.setters.setFarmSupplies(prev => {
+      const previous = prev || {};
+      const current = previous[supplyType] || 0;
+      return { ...previous, [supplyType]: Math.max(0, current - 1) };
+    });
+
+    if (!keepSelection) {
+      this.setters.setSelectedSupply(null);
+    }
+  }
+
   buySeed(seedType) {
     const { money, marketPrices } = this.state;
     const price = (marketPrices && marketPrices[seedType]) || CROPS[seedType].price;
 
     if (money >= price) {
-      this.setters.setMoney(prev => prev - price);
+      this.setters.setSelectedSupply(null);
       this.setters.setSelectedSeed(seedType);
       this.setters.setShowShop(false);
-      this.notify(`購買了 ${CROPS[seedType].name} 種子！`, { type: 'success' });
+      this.notify(`準備種植 ${CROPS[seedType].name}，記得找到空地！`, { type: 'success' });
     } else {
       this.notify('金錢不足！', { type: 'error' });
     }
   }
 
+  buySupply(supplyType) {
+    const supply = FARM_SUPPLIES[supplyType];
+    if (!supply) return;
+
+    const { money } = this.state;
+    if (money < supply.price) {
+      this.notify('金錢不足，無法購買！', { type: 'error' });
+      return;
+    }
+
+    this.setters.setMoney(prev => prev - supply.price);
+    this.setters.setFarmSupplies(prev => {
+      const previous = prev || {};
+      return { ...previous, [supplyType]: (previous[supplyType] || 0) + 1 };
+    });
+    this.setters.setShowSupplyShop(false);
+    this.notify(`購買了 ${supply.emoji} ${supply.name}！`, { type: 'success' });
+  }
+
+  selectSupply(supplyType) {
+    if (!FARM_SUPPLIES[supplyType]) {
+      this.setters.setSelectedSupply(null);
+      return;
+    }
+
+    const { selectedSupply } = this.state;
+    if (selectedSupply === supplyType) {
+      this.setters.setSelectedSupply(null);
+      return;
+    }
+
+    this.setters.setSelectedSeed(null);
+    this.setters.setSelectedSupply(supplyType);
+    this.notify(`已選擇 ${FARM_SUPPLIES[supplyType].name}，點擊目標即可使用。`, { type: 'info' });
+  }
+
+  applySupply(plotId) {
+    const { selectedSupply, farm, farmSupplies } = this.state;
+    if (!selectedSupply) return false;
+
+    const supply = FARM_SUPPLIES[selectedSupply];
+    if (!supply) {
+      this.setters.setSelectedSupply(null);
+      return false;
+    }
+
+    if (selectedSupply === 'medicine') {
+      this.notify('營養劑需要在動物卡片上使用喔！', { type: 'info' });
+      this.setters.setSelectedSupply(null);
+      return false;
+    }
+
+    const plot = farm.find(p => p.id === plotId);
+    if (!plot) return false;
+
+    const available = farmSupplies?.[selectedSupply] || 0;
+    if (available <= 0) {
+      this.notify('用品不足，先去補貨吧！', { type: 'warning' });
+      this.setters.setSelectedSupply(null);
+      return true;
+    }
+
+    if (selectedSupply === 'fertilizer') {
+      if (plot.fertilized) {
+        this.notify('這塊土地的土壤已經肥沃了！', { type: 'info' });
+        return true;
+      }
+
+      if (plot.crop && plot.ready) {
+        this.notify('作物已成熟，無需再施肥！', { type: 'info' });
+        return true;
+      }
+
+      this.setters.setFarm(prev => prev.map(p => (
+        p.id === plotId
+          ? { ...p, fertilized: true }
+          : p
+      )));
+      this.consumeSupply('fertilizer', { keepSelection: available > 1 });
+      this.notify('施用了有機肥料，作物成長速度提升！', { type: 'success' });
+      return true;
+    }
+
+    if (selectedSupply === 'pesticide') {
+      if (!plot.pest) {
+        this.notify('這塊土地沒有害蟲。', { type: 'info' });
+        return true;
+      }
+
+      this.setters.setFarm(prev => prev.map(p => (
+        p.id === plotId
+          ? { ...p, pest: false }
+          : p
+      )));
+      this.consumeSupply('pesticide', { keepSelection: available > 1 });
+      this.notify('成功清除害蟲，作物恢復生長！', { type: 'success' });
+      return true;
+    }
+
+    return false;
+  }
+
   plantSeed(plotId) {
-    const { selectedSeed, tools, buildings, energy } = this.state;
+    const { selectedSeed, tools, buildings, energy, money, marketPrices } = this.state;
     if (!selectedSeed) return;
+
+    const price = (marketPrices && marketPrices[selectedSeed]) || CROPS[selectedSeed].price;
+    if (money < price) {
+      this.notify('金錢不足，無法種植！', { type: 'error' });
+      return;
+    }
 
     const energyCost = Math.max(1, 10 - TOOLS[tools].energyReduction - (buildings?.well ? 5 : 0));
     if (energy < energyCost) {
@@ -41,15 +161,25 @@ export class GameEngine {
       return;
     }
 
-    this.setters.setFarm(prev => prev.map(plot =>
-      plot.id === plotId && !plot.crop
-        ? { ...plot, crop: selectedSeed, plantTime: Date.now(), watered: false, ready: false, pest: false }
-        : plot
-    ));
+    let planted = false;
+    this.setters.setFarm(prev => prev.map(plot => {
+      if (plot.id === plotId && !plot.crop) {
+        planted = true;
+        return { ...plot, crop: selectedSeed, plantTime: Date.now(), watered: false, ready: false, pest: false };
+      }
+      return plot;
+    }));
 
+    if (!planted) {
+      this.notify('這塊土地已經有作物了！', { type: 'info' });
+      return;
+    }
+
+    this.setters.setMoney(prev => prev - price);
     this.setters.setEnergy(prev => Math.max(0, prev - energyCost));
     this.setters.setExperience(prev => prev + 5);
     this.setters.setSelectedSeed(null);
+    this.setters.setSelectedSupply(null);
     this.notify(`種植了 ${CROPS[selectedSeed].name}！`, { type: 'success' });
   }
 
@@ -73,7 +203,7 @@ export class GameEngine {
     this.setters.setExperience(prev => prev + 10);
     this.setters.setFarm(prev => prev.map(p =>
       p.id === plotId
-        ? { ...p, crop: null, plantTime: null, watered: false, ready: false, pest: false }
+        ? { ...p, crop: null, plantTime: null, watered: false, ready: false, pest: false, fertilized: false }
         : p
     ));
 
@@ -117,6 +247,7 @@ export class GameEngine {
         happiness: animal.happiness,
         hunger: 70,
         lastFed: Date.now(),
+        sick: false,
         name: `${animal.name}${prev.filter(a => a.type === animalType).length + 1}`,
       }]);
       this.setters.setShowAnimalShop(false);
@@ -197,6 +328,37 @@ export class GameEngine {
         : a
     ));
     this.notify(`餵食了 ${animal.name}！`, { type: 'success' });
+  }
+
+  treatAnimal(animalId) {
+    const { animals, farmSupplies } = this.state;
+    const animal = animals.find(a => a.id === animalId);
+    if (!animal) return;
+
+    const medicineCount = farmSupplies?.medicine || 0;
+    if (medicineCount <= 0) {
+      this.notify('沒有營養劑可用，記得先去補貨！', { type: 'warning' });
+      this.setters.setSelectedSupply(null);
+      return;
+    }
+
+    if (!animal.sick) {
+      this.notify(`${animal.name} 狀態良好，暫時不需要治療。`, { type: 'info' });
+      return;
+    }
+
+    this.setters.setAnimals(prev => prev.map(a =>
+      a.id === animalId
+        ? {
+            ...a,
+            sick: false,
+            happiness: Math.min(100, (a.happiness ?? ANIMALS[a.type].happiness) + 25),
+          }
+        : a
+    ));
+
+    this.consumeSupply('medicine', { keepSelection: medicineCount > 1 });
+    this.notify(`已替 ${animal.name} 使用營養劑，狀況好多了！`, { type: 'success' });
   }
 }
 

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -1,4 +1,21 @@
-import { CROPS, ANIMALS, BUILDINGS, TOOLS, FARM_SUPPLIES } from '../data/GameCatalog';
+import { CROPS, ANIMALS, BUILDINGS, TOOLS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from '../data/GameCatalog';
+
+export const BASE_FARM_PLOTS = 25;
+export const FARM_EXPANSION_BATCH = 5;
+export const MAX_FARM_PLOTS = 45;
+export const BASE_ANIMAL_CAPACITY = 6;
+export const ANIMAL_CAPACITY_STEP = 3;
+export const MAX_ANIMAL_CAPACITY = 24;
+
+export const getFarmExpansionCost = (currentPlotCount) => {
+  const purchasedBatches = Math.max(0, Math.floor((currentPlotCount - BASE_FARM_PLOTS) / FARM_EXPANSION_BATCH));
+  return 500 + purchasedBatches * 200;
+};
+
+export const getAnimalHousingExpansionCost = (currentCapacity) => {
+  const purchasedSteps = Math.max(0, Math.floor((currentCapacity - BASE_ANIMAL_CAPACITY) / ANIMAL_CAPACITY_STEP));
+  return 650 + purchasedSteps * 250;
+};
 
 export class GameEngine {
   constructor({ stateRef, setters, notifier }) {
@@ -60,6 +77,78 @@ export class GameEngine {
     });
     this.setters.setShowSupplyShop(false);
     this.notify(`購買了 ${supply.emoji} ${supply.name}！`, { type: 'success' });
+  }
+
+  expandFarm() {
+    const { money, farm, buildings } = this.state;
+    if (!Array.isArray(farm)) return;
+
+    if (farm.length >= MAX_FARM_PLOTS) {
+      this.notify('農地已經擴建到極限了！', { type: 'info' });
+      return;
+    }
+
+    const price = getFarmExpansionCost(farm.length);
+    if (money < price) {
+      this.notify('金錢不足，暫時無法擴建農地。', { type: 'error' });
+      return;
+    }
+
+    const plotsToAdd = Math.min(FARM_EXPANSION_BATCH, MAX_FARM_PLOTS - farm.length);
+    const hasGreenhouse = Boolean(buildings?.greenhouse);
+
+    this.setters.setMoney(prev => prev - price);
+    this.setters.setFarm(prev => {
+      const safePrev = Array.isArray(prev) ? prev : [];
+      const next = [...safePrev];
+      const startId = safePrev.reduce((max, plot) => Math.max(max, plot.id ?? -1), -1) + 1;
+
+      for (let i = 0; i < plotsToAdd; i += 1) {
+        next.push({
+          id: startId + i,
+          crop: null,
+          plantTime: null,
+          watered: false,
+          fertilized: false,
+          greenhouse: hasGreenhouse,
+          pest: false,
+          pestDays: 0,
+          ready: false,
+        });
+      }
+
+      return next;
+    });
+
+    this.notify(`農地擴建完成，新增 ${plotsToAdd} 格土地！`, { type: 'success' });
+  }
+
+  expandAnimalHousing() {
+    const { money, animalCapacity } = this.state;
+    const currentCapacity = Math.max(animalCapacity || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY);
+
+    if (currentCapacity >= MAX_ANIMAL_CAPACITY) {
+      this.notify('動物欄位已達上限，無法再擴充。', { type: 'info' });
+      return;
+    }
+
+    const price = getAnimalHousingExpansionCost(currentCapacity);
+    if (money < price) {
+      this.notify('金錢不足，暫時無法擴建動物欄。', { type: 'error' });
+      return;
+    }
+
+    const addedCapacity = Math.min(ANIMAL_CAPACITY_STEP, MAX_ANIMAL_CAPACITY - currentCapacity);
+
+    this.setters.setMoney(prev => prev - price);
+    if (typeof this.setters.setAnimalCapacity === 'function') {
+      this.setters.setAnimalCapacity(prev => {
+        const base = Math.max(prev || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY);
+        return Math.min(base + addedCapacity, MAX_ANIMAL_CAPACITY);
+      });
+    }
+
+    this.notify(`新增 ${addedCapacity} 個動物欄位，快去迎接新伙伴吧！`, { type: 'success' });
   }
 
   selectSupply(supplyType) {
@@ -199,7 +288,10 @@ export class GameEngine {
     const sellPrice = Math.floor(basePrice * bonus);
 
     this.setters.setMoney(prev => prev + sellPrice);
-    this.setters.setInventory(prev => ({ ...prev, [crop]: prev[crop] + 1 }));
+    this.setters.setInventory(prev => ({
+      ...prev,
+      [crop]: ((prev && prev[crop]) || 0) + 1,
+    }));
     this.setters.setExperience(prev => prev + 10);
     this.setters.setFarm(prev => prev.map(p =>
       p.id === plotId
@@ -229,13 +321,19 @@ export class GameEngine {
   }
 
   buyAnimal(animalType) {
-    const { money } = this.state;
+    const { money, animals = [], animalCapacity } = this.state;
     const animal = ANIMALS[animalType];
     const requiredShelter = animal.shelter;
 
     if (requiredShelter && !this.state.buildings?.[requiredShelter]) {
       const shelterName = BUILDINGS[requiredShelter].name;
       this.notify(`需要先建造 ${shelterName} 才能飼養 ${animal.name}！`, { type: 'warning' });
+      return;
+    }
+
+    const capacityLimit = Math.max(animalCapacity || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY);
+    if ((animals?.length || 0) >= capacityLimit) {
+      this.notify('動物欄位已滿，請先擴建或整理空間。', { type: 'warning' });
       return;
     }
 
@@ -296,6 +394,80 @@ export class GameEngine {
       this.notify(`升級工具：${tool.name}！`, { type: 'success' });
     } else {
       this.notify('金錢不足！', { type: 'error' });
+    }
+  }
+
+  getInventorySaleValue(itemKey, quantity) {
+    const count = quantity ?? (this.state.inventory?.[itemKey] || 0);
+    if (!count || count <= 0) {
+      return 0;
+    }
+
+    if (CROPS[itemKey]) {
+      const { marketPrices } = this.state;
+      const basePrice = (marketPrices && marketPrices[itemKey]) || CROPS[itemKey].sellPrice;
+      return Math.max(0, Math.floor(basePrice * count));
+    }
+
+    const product = ANIMAL_PRODUCTS[itemKey];
+    if (!product) {
+      return 0;
+    }
+
+    const { buildings, animals } = this.state;
+    const animalType = product.animal;
+    let multiplier = 1;
+
+    if (animalType && ANIMALS[animalType]) {
+      const animalData = ANIMALS[animalType];
+      const shelterKey = animalData.shelter;
+      if (shelterKey && buildings?.[shelterKey]) {
+        multiplier *= BUILDINGS[shelterKey].boost || 1;
+      }
+
+      const ownedAnimals = (animals || []).filter(a => a.type === animalType);
+      if (ownedAnimals.length > 0) {
+        const totalHappiness = ownedAnimals.reduce((sum, current) => sum + (current.happiness ?? animalData.happiness ?? 50), 0);
+        const averageHappiness = totalHappiness / ownedAnimals.length;
+        const happinessFactor = 0.6 + (averageHappiness / 150);
+        multiplier *= Math.max(0.6, Math.min(1.6, happinessFactor));
+      } else {
+        multiplier *= 0.6;
+      }
+    }
+
+    return Math.max(0, Math.floor(product.basePrice * multiplier * count));
+  }
+
+  sellInventoryItem(itemKey, { quantity } = {}) {
+    const inventory = this.state.inventory || {};
+    const available = inventory[itemKey] || 0;
+    if (!available || available <= 0) {
+      this.notify('庫存不足，無法出售。', { type: 'warning' });
+      return;
+    }
+
+    const amountToSell = Math.min(quantity ?? available, available);
+    const saleValue = this.getInventorySaleValue(itemKey, amountToSell);
+    if (saleValue <= 0) {
+      this.notify('這些物品目前沒有買家。', { type: 'info' });
+      return;
+    }
+
+    this.setters.setInventory(prev => ({
+      ...prev,
+      [itemKey]: Math.max(0, (prev?.[itemKey] || 0) - amountToSell),
+    }));
+
+    this.setters.setMoney(prev => prev + saleValue);
+
+    const product = ANIMAL_PRODUCTS[itemKey];
+    if (product) {
+      this.notify(`出售了 ${amountToSell} 份${product.name}，獲得 $${saleValue}！`, { type: 'success' });
+    } else if (CROPS[itemKey]) {
+      this.notify(`出售了 ${amountToSell} 份${CROPS[itemKey].name}，獲得 $${saleValue}！`, { type: 'success' });
+    } else {
+      this.notify(`出售物品獲得 $${saleValue}！`, { type: 'success' });
     }
   }
 

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -46,6 +46,26 @@ export class GameEngine {
     }
   }
 
+  getGreenhouseCount(buildings = this.state.buildings) {
+    if (!buildings) {
+      return 0;
+    }
+
+    const rawValue = buildings.greenhouse;
+    if (typeof rawValue === 'number') {
+      return Math.max(0, Math.floor(rawValue));
+    }
+
+    if (rawValue) {
+      const { farm } = this.state;
+      if (Array.isArray(farm)) {
+        return farm.reduce((count, plot) => count + (plot.greenhouse ? 1 : 0), 0);
+      }
+    }
+
+    return 0;
+  }
+
   buySeed(seedType) {
     const { money, marketPrices } = this.state;
     const price = (marketPrices && marketPrices[seedType]) || CROPS[seedType].price;
@@ -80,7 +100,7 @@ export class GameEngine {
   }
 
   expandFarm() {
-    const { money, farm, buildings } = this.state;
+    const { money, farm } = this.state;
     if (!Array.isArray(farm)) return;
 
     if (farm.length >= MAX_FARM_PLOTS) {
@@ -95,8 +115,6 @@ export class GameEngine {
     }
 
     const plotsToAdd = Math.min(FARM_EXPANSION_BATCH, MAX_FARM_PLOTS - farm.length);
-    const hasGreenhouse = Boolean(buildings?.greenhouse);
-
     this.setters.setMoney(prev => prev - price);
     this.setters.setFarm(prev => {
       const safePrev = Array.isArray(prev) ? prev : [];
@@ -110,7 +128,7 @@ export class GameEngine {
           plantTime: null,
           watered: false,
           fertilized: false,
-          greenhouse: hasGreenhouse,
+          greenhouse: false,
           pest: false,
           pestDays: 0,
           ready: false,
@@ -293,11 +311,20 @@ export class GameEngine {
       [crop]: ((prev && prev[crop]) || 0) + 1,
     }));
     this.setters.setExperience(prev => prev + 10);
-    this.setters.setFarm(prev => prev.map(p =>
+    this.setters.setFarm(prev => prev.map(p => (
       p.id === plotId
-        ? { ...p, crop: null, plantTime: null, watered: false, ready: false, pest: false, pestDays: 0, fertilized: false }
+        ? {
+            ...p,
+            crop: null,
+            plantTime: null,
+            watered: false,
+            ready: false,
+            pest: false,
+            pestDays: 0,
+            fertilized: false,
+          }
         : p
-    ));
+    )));
 
     this.notify(`收成了 ${CROPS[crop].emoji}！獲得 $${sellPrice}`, { type: 'success' });
   }
@@ -356,8 +383,41 @@ export class GameEngine {
   }
 
   buyBuilding(buildingType) {
-    const { money, buildings } = this.state;
+    const { money, buildings, farm, pendingGreenhousePlacement } = this.state;
     const building = BUILDINGS[buildingType];
+
+    if (!building) {
+      return;
+    }
+
+    if (buildingType === 'greenhouse') {
+      if (pendingGreenhousePlacement) {
+        this.notify('已經購買溫室模組，請先在農地上選擇位置。', { type: 'info' });
+        return;
+      }
+
+      const availablePlots = Array.isArray(farm)
+        ? farm.filter(plot => !plot.greenhouse)
+        : [];
+
+      if (availablePlots.length === 0) {
+        this.notify('所有農地都已升級為溫室囉！', { type: 'info' });
+        return;
+      }
+
+      if (money < building.price) {
+        this.notify('金錢不足，暫時無法購買溫室模組。', { type: 'error' });
+        return;
+      }
+
+      this.setters.setMoney(prev => prev - building.price);
+      if (typeof this.setters.setPendingGreenhousePlacement === 'function') {
+        this.setters.setPendingGreenhousePlacement(true);
+      }
+      this.setters.setShowBuildingShop(false);
+      this.notify('溫室模組準備就緒，請點選一格農地完成建造。', { type: 'success' });
+      return;
+    }
 
     if (buildings?.[buildingType]) {
       this.notify('已經擁有此建築！', { type: 'info' });
@@ -368,17 +428,63 @@ export class GameEngine {
       this.setters.setMoney(prev => prev - building.price);
       this.setters.setBuildings(prev => ({ ...prev, [buildingType]: true }));
 
-      if (buildingType === 'greenhouse') {
-        this.setters.setFarm(prev => prev.map(plot => (
-          plot.greenhouse ? plot : { ...plot, greenhouse: true }
-        )));
-      }
-
       this.setters.setShowBuildingShop(false);
       this.notify(`建造了 ${building.emoji} ${building.name}！`, { type: 'success' });
     } else {
       this.notify('金錢不足！', { type: 'error' });
     }
+  }
+
+  placeGreenhouse(plotId) {
+    const { pendingGreenhousePlacement, farm } = this.state;
+    if (!pendingGreenhousePlacement) {
+      return false;
+    }
+
+    if (!Array.isArray(farm) || farm.length === 0) {
+      this.notify('目前沒有可用的農地資料，稍後再試試看。', { type: 'warning' });
+      return true;
+    }
+
+    const targetPlot = farm.find(plot => plot.id === plotId);
+    if (!targetPlot) {
+      this.notify('無法在這裡建造溫室。', { type: 'error' });
+      return true;
+    }
+
+    if (targetPlot.greenhouse) {
+      this.notify('這塊土地已經是溫室囉！', { type: 'info' });
+      return true;
+    }
+
+    let built = false;
+    this.setters.setFarm(prev => prev.map(plot => {
+      if (plot.id === plotId && !plot.greenhouse) {
+        built = true;
+        return { ...plot, greenhouse: true };
+      }
+      return plot;
+    }));
+
+    if (!built) {
+      this.notify('暫時無法建造，請確認土地是否空閒。', { type: 'warning' });
+      return true;
+    }
+
+    if (typeof this.setters.setPendingGreenhousePlacement === 'function') {
+      this.setters.setPendingGreenhousePlacement(false);
+    }
+
+    if (typeof this.setters.setBuildings === 'function') {
+      this.setters.setBuildings(prev => {
+        const previous = prev || {};
+        const count = this.getGreenhouseCount(previous);
+        return { ...previous, greenhouse: count + 1 };
+      });
+    }
+
+    this.notify('溫室建造完成，這格土地不再受天氣影響！', { type: 'success' });
+    return true;
   }
 
   buyTool(toolType) {

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -260,9 +260,16 @@ export class GameEngine {
       ...prev,
       [seedKey]: (prev?.[seedKey] || 0) + amount,
     }));
+    if (typeof this.setters.setFarmSupplies === 'function') {
+      this.setters.setFarmSupplies(prev => {
+        const previous = prev || {};
+        const current = previous[seedKey] || 0;
+        return { ...previous, [seedKey]: current + amount };
+      });
+    }
     this.setters.setSelectedSupply(null);
     this.setters.setSelectedSeed(seedType);
-    this.notify(`購買了 ${amount} 包${crop.name}種子，已存入倉庫並可直接種植。`, { type: 'success' });
+    this.notify(`購買了 ${amount} 包${crop.name}種子，已存入農務用品區，可隨時備用。`, { type: 'success' });
   }
 
   buySeed(seedType, options) {
@@ -509,6 +516,13 @@ export class GameEngine {
         ...prev,
         [seedKey]: Math.max(0, (prev?.[seedKey] || 0) - 1),
       }));
+      if (typeof this.setters.setFarmSupplies === 'function') {
+        this.setters.setFarmSupplies(prev => {
+          const previous = prev || {};
+          const current = previous[seedKey] || 0;
+          return { ...previous, [seedKey]: Math.max(0, current - 1) };
+        });
+      }
     } else {
       remainingMoney = money - price;
       this.setters.setMoney(prev => prev - price);
@@ -644,6 +658,7 @@ export class GameEngine {
         lastFed: Date.now(),
         sick: false,
         name: `${animal.name}${baseIndex + index + 1}`,
+        productReady: 0,
       }));
       return [...prevList, ...additions];
     });
@@ -670,6 +685,19 @@ export class GameEngine {
     if (!butcher || !butcher.product) {
       this.notify('這類動物無法進行屠宰。', { type: 'warning' });
       return;
+    }
+
+    if (animalData.product) {
+      const readyAmount = Math.max(0, Math.floor(animal.productReady || 0));
+      if (readyAmount > 0) {
+        const readyProduct = ANIMAL_PRODUCTS[animalData.product];
+        this.setters.setInventory(prev => ({
+          ...prev,
+          [animalData.product]: (prev?.[animalData.product] || 0) + readyAmount,
+        }));
+        const readyLabel = readyProduct ? readyProduct.name : '產物';
+        this.notify(`在處理 ${animal.name} 前，先收集了 ${readyLabel} x${readyAmount}。`, { type: 'info' });
+      }
     }
 
     const product = ANIMAL_PRODUCTS[butcher.product];
@@ -931,6 +959,14 @@ export class GameEngine {
       [itemKey]: Math.max(0, (prev?.[itemKey] || 0) - amountToSell),
     }));
 
+    if (itemKey.startsWith('seed_') && typeof this.setters.setFarmSupplies === 'function') {
+      this.setters.setFarmSupplies(prev => {
+        const previous = prev || {};
+        const current = previous[itemKey] || 0;
+        return { ...previous, [itemKey]: Math.max(0, current - amountToSell) };
+      });
+    }
+
     this.setters.setMoney(prev => prev + saleValue);
 
     if (itemKey.startsWith('seed_')) {
@@ -1015,6 +1051,47 @@ export class GameEngine {
 
     this.consumeSupply('medicine', { keepSelection: medicineCount > 1 });
     this.notify(`已替 ${animal.name} 使用營養劑，狀況好多了！`, { type: 'success' });
+  }
+
+  collectAnimalProduct(animalId) {
+    const { animals = [] } = this.state;
+    if (!Array.isArray(animals) || animals.length === 0) {
+      this.notify('目前沒有動物可以收集產物。', { type: 'info' });
+      return;
+    }
+
+    const animal = animals.find(entry => entry.id === animalId);
+    if (!animal) {
+      this.notify('找不到這隻動物。', { type: 'error' });
+      return;
+    }
+
+    const animalData = ANIMALS[animal.type];
+    if (!animalData || !animalData.product) {
+      this.notify('這隻動物不會產出可收集的物品。', { type: 'info' });
+      return;
+    }
+
+    const readyAmount = Math.max(0, Math.floor(animal.productReady || 0));
+    if (readyAmount <= 0) {
+      this.notify('目前沒有可以收集的產物。', { type: 'info' });
+      return;
+    }
+
+    const product = ANIMAL_PRODUCTS[animalData.product];
+    this.setters.setAnimals(prev => prev.map(entry => (
+      entry.id === animalId
+        ? { ...entry, productReady: 0, lastCollected: Date.now() }
+        : entry
+    )));
+
+    this.setters.setInventory(prev => ({
+      ...prev,
+      [animalData.product]: (prev?.[animalData.product] || 0) + readyAmount,
+    }));
+
+    const label = product ? `${product.emoji} ${product.name}` : '產物';
+    this.notify(`收集了 ${label} x${readyAmount}，已送入倉庫。`, { type: 'success' });
   }
 }
 

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -1,7 +1,7 @@
 import { CROPS, ANIMALS, BUILDINGS, TOOLS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from '../data/GameCatalog';
 
 export const BASE_FARM_PLOTS = 25;
-export const FARM_EXPANSION_BATCH = 5;
+export const FARM_EXPANSION_BATCH = 1;
 export const MAX_FARM_PLOTS = 45;
 export const BASE_ANIMAL_CAPACITY = 6;
 export const ANIMAL_CAPACITY_STEP = 1;
@@ -11,7 +11,8 @@ export const getFarmExpansionCost = (currentPlotCount) => {
   if (currentPlotCount >= MAX_FARM_PLOTS) {
     return null;
   }
-  return 5000;
+  const expansionsPurchased = Math.max(0, currentPlotCount - BASE_FARM_PLOTS);
+  return 1000 + (expansionsPurchased * 250);
 };
 
 export const getAnimalHousingExpansionCost = (currentCapacity) => {
@@ -19,6 +20,38 @@ export const getAnimalHousingExpansionCost = (currentCapacity) => {
     return null;
   }
   return 2500;
+};
+
+export const BUILDING_UPGRADES = {
+  sprinkler: [
+    { level: 1, cost: 650, coverage: 12, manualWaterCost: 3, plantingDiscount: 3, description: '覆蓋 12 格農地，自動補水並減少播種體力。' },
+    { level: 2, cost: 900, coverage: 24, manualWaterCost: 2, plantingDiscount: 4, description: '覆蓋範圍擴大至 24 格，澆水幾乎不費力。' },
+    { level: 3, cost: 1400, coverage: 36, manualWaterCost: 1, plantingDiscount: 5, description: '灌溉到 36 格農地並極大幅度節省體力。' },
+    { level: 4, cost: 2200, coverage: MAX_FARM_PLOTS, manualWaterCost: 1, plantingDiscount: 6, description: '全區自動灌溉，維持土壤最佳濕度。' },
+  ],
+  silo: [
+    { level: 1, cost: 800, sellBonus: 0.05, description: '作物售價 +5%，減少腐壞。' },
+    { level: 2, cost: 1200, sellBonus: 0.1, description: '作物售價 +10%，可長期保存。' },
+    { level: 3, cost: 1800, sellBonus: 0.18, description: '作物售價 +18%，高效率倉儲。' },
+  ],
+  barn: [
+    { level: 1, cost: 1000, boost: 1.2, description: '提供牛羊穩定環境，提升產量。' },
+    { level: 2, cost: 1500, boost: 1.35, description: '擴增飼槽與溫控，提高品質。' },
+    { level: 3, cost: 2200, boost: 1.5, description: '頂級穀倉，讓牛羊更快樂。' },
+  ],
+  chickenCoop: [
+    { level: 1, cost: 500, boost: 1.3, description: '舒適雞舍，提升產蛋率。' },
+    { level: 2, cost: 850, boost: 1.45, description: '自動餵食設備維持穩定產量。' },
+    { level: 3, cost: 1200, boost: 1.6, description: '氣候調節雞舍，全年高產。' },
+  ],
+  pigPen: [
+    { level: 1, cost: 400, boost: 1.2, description: '泥土樂園讓豬豬更放鬆。' },
+    { level: 2, cost: 700, boost: 1.35, description: '增設噴霧與運動空間，提升肉質。' },
+  ],
+  pond: [
+    { level: 1, cost: 600, boost: 1.3, description: '自然池塘讓水鳥安心棲息。' },
+    { level: 2, cost: 950, boost: 1.45, description: '擴建浮台與遮蔭範圍。' },
+  ],
 };
 
 export class GameEngine {
@@ -74,6 +107,108 @@ export class GameEngine {
     }
 
     return 0;
+  }
+
+  getBuildingLevel(buildings = this.state.buildings, key) {
+    if (!buildings) {
+      return 0;
+    }
+
+    const value = buildings[key];
+    if (typeof value === 'number') {
+      return Math.max(0, Math.floor(value));
+    }
+
+    return value ? 1 : 0;
+  }
+
+  getBuildingUpgradeInfo(key, level) {
+    const upgrades = BUILDING_UPGRADES[key];
+    if (!upgrades) {
+      return null;
+    }
+
+    return upgrades.find(entry => entry.level === level) || null;
+  }
+
+  getNextBuildingUpgrade(key, currentLevel) {
+    const upgrades = BUILDING_UPGRADES[key];
+    if (!upgrades) {
+      return null;
+    }
+
+    return upgrades.find(entry => entry.level === currentLevel + 1) || null;
+  }
+
+  getSprinklerLevel(buildings = this.state.buildings) {
+    return this.getBuildingLevel(buildings, 'sprinkler');
+  }
+
+  getSprinklerCoverage(buildings = this.state.buildings) {
+    const level = this.getSprinklerLevel(buildings);
+    if (level <= 0) {
+      return 0;
+    }
+
+    const info = this.getBuildingUpgradeInfo('sprinkler', level);
+    return info?.coverage ?? 0;
+  }
+
+  getSprinklerManualWaterCost() {
+    const level = this.getSprinklerLevel();
+    if (level <= 0) {
+      return 5;
+    }
+
+    const info = this.getBuildingUpgradeInfo('sprinkler', level);
+    if (info && typeof info.manualWaterCost === 'number') {
+      return Math.max(1, info.manualWaterCost);
+    }
+
+    return 2;
+  }
+
+  getSprinklerPlantingDiscount() {
+    const level = this.getSprinklerLevel();
+    if (level <= 0) {
+      return 0;
+    }
+
+    const info = this.getBuildingUpgradeInfo('sprinkler', level);
+    if (info && typeof info.plantingDiscount === 'number') {
+      return Math.max(0, info.plantingDiscount);
+    }
+
+    return 3;
+  }
+
+  getSiloBonus(buildings = this.state.buildings) {
+    const level = this.getBuildingLevel(buildings, 'silo');
+    if (level <= 0) {
+      return 0;
+    }
+
+    const info = this.getBuildingUpgradeInfo('silo', level);
+    return info?.sellBonus ?? 0;
+  }
+
+  getShelterBoost(buildings = this.state.buildings, shelterKey) {
+    if (!shelterKey) {
+      return 1;
+    }
+
+    const level = this.getBuildingLevel(buildings, shelterKey);
+    if (level <= 0) {
+      return 1;
+    }
+
+    const info = this.getBuildingUpgradeInfo(shelterKey, level);
+    if (info && typeof info.boost === 'number') {
+      return info.boost;
+    }
+
+    const building = BUILDINGS[shelterKey];
+    return building?.boost ?? 1;
   }
 
   getSeedKey(seedType) {
@@ -175,6 +310,10 @@ export class GameEngine {
     }
 
     const plotsToAdd = Math.min(FARM_EXPANSION_BATCH, MAX_FARM_PLOTS - farm.length);
+    let resultingSize = farm.length;
+    const sprinklerLevel = this.getSprinklerLevel();
+    const coverage = this.getSprinklerCoverage();
+    const wasCovered = farm.length <= coverage;
     this.setters.setMoney(prev => prev - price);
     this.setters.setFarm(prev => {
       const safePrev = Array.isArray(prev) ? prev : [];
@@ -195,10 +334,15 @@ export class GameEngine {
         });
       }
 
+      resultingSize = next.length;
       return next;
     });
 
     this.notify(`農地擴建完成，新增 ${plotsToAdd} 格土地！`, { type: 'success' });
+
+    if (sprinklerLevel > 0 && coverage > 0 && wasCovered && resultingSize > coverage) {
+      this.notify(`🚿 自動灑水器目前僅能覆蓋 ${coverage} 格，記得升級避免作物缺水。`, { type: 'warning' });
+    }
   }
 
   expandAnimalHousing() {
@@ -318,7 +462,7 @@ export class GameEngine {
   }
 
   plantSeed(plotId) {
-    const { selectedSeed, tools, buildings, energy, money, marketPrices, inventory, season, farm } = this.state;
+    const { selectedSeed, tools, energy, money, marketPrices, inventory, season, farm } = this.state;
     if (!selectedSeed) return;
 
     const price = (marketPrices && marketPrices[selectedSeed]) || CROPS[selectedSeed].price;
@@ -333,7 +477,8 @@ export class GameEngine {
       return;
     }
 
-    const energyCost = Math.max(1, 10 - TOOLS[tools].energyReduction - (buildings?.sprinkler ? 5 : 0));
+    const irrigationDiscount = this.getSprinklerPlantingDiscount();
+    const energyCost = Math.max(1, 10 - TOOLS[tools].energyReduction - irrigationDiscount);
     if (energy < energyCost) {
       this.notify('體力不足！', { type: 'warning' });
       return;
@@ -427,8 +572,8 @@ export class GameEngine {
   }
 
   waterPlot(plotId) {
-    const { energy, buildings } = this.state;
-    const energyCost = buildings?.sprinkler ? 1 : 5;
+    const { energy } = this.state;
+    const energyCost = this.getSprinklerManualWaterCost();
     if (energy < energyCost) {
       this.notify('體力不足，無法澆水！', { type: 'warning' });
       return;
@@ -449,7 +594,7 @@ export class GameEngine {
     const animal = ANIMALS[animalType];
     const requiredShelter = animal.shelter;
 
-    if (requiredShelter && !this.state.buildings?.[requiredShelter]) {
+    if (requiredShelter && this.getBuildingLevel(this.state.buildings, requiredShelter) <= 0) {
       const shelterName = BUILDINGS[requiredShelter].name;
       this.notify(`需要先建造 ${shelterName} 才能飼養 ${animal.name}！`, { type: 'warning' });
       return;
@@ -551,7 +696,34 @@ export class GameEngine {
       return;
     }
 
-    if (buildings?.[buildingType]) {
+    const currentLevel = this.getBuildingLevel(buildings, buildingType);
+    const upgradeInfo = this.getNextBuildingUpgrade(buildingType, currentLevel);
+    if (upgradeInfo) {
+      if (money < upgradeInfo.cost) {
+        this.notify('金錢不足，暫時無法升級建築。', { type: 'error' });
+        return;
+      }
+
+      this.setters.setMoney(prev => prev - upgradeInfo.cost);
+      this.setters.setBuildings(prev => ({
+        ...prev,
+        [buildingType]: upgradeInfo.level,
+      }));
+
+      this.setters.setShowBuildingShop(false);
+      const action = currentLevel > 0 ? '升級' : '建造';
+      this.notify(`${action}了 ${building.emoji} ${building.name}（Lv${upgradeInfo.level}）！`, { type: 'success' });
+
+      const detail = buildingType === 'sprinkler'
+        ? `自動灑水範圍提升至 ${upgradeInfo.coverage} 格。`
+        : upgradeInfo.description;
+      if (detail) {
+        this.notify(detail, { type: 'info' });
+      }
+      return;
+    }
+
+    if (currentLevel > 0) {
       this.notify('已經擁有此建築！', { type: 'info' });
       return;
     }
@@ -678,7 +850,9 @@ export class GameEngine {
     if (CROPS[itemKey]) {
       const { marketPrices } = this.state;
       const basePrice = (marketPrices && marketPrices[itemKey]) || CROPS[itemKey].sellPrice;
-      return Math.max(0, Math.floor(basePrice * count));
+      const siloBonus = this.getSiloBonus();
+      const adjustedPrice = basePrice * count * (1 + siloBonus);
+      return Math.max(0, Math.floor(adjustedPrice));
     }
 
     const product = ANIMAL_PRODUCTS[itemKey];
@@ -693,9 +867,7 @@ export class GameEngine {
     if (animalType && ANIMALS[animalType]) {
       const animalData = ANIMALS[animalType];
       const shelterKey = animalData.shelter;
-      if (shelterKey && buildings?.[shelterKey]) {
-        multiplier *= BUILDINGS[shelterKey].boost || 1;
-      }
+      multiplier *= this.getShelterBoost(buildings, shelterKey);
 
       const ownedAnimals = (animals || []).filter(a => a.type === animalType);
       if (ownedAnimals.length > 0) {

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -211,6 +211,41 @@ export class GameEngine {
     return building?.boost ?? 1;
   }
 
+  getToolUpgradeLevel(toolKey = this.state.tools) {
+    const { toolLevels } = this.state;
+    if (!toolKey) {
+      return 0;
+    }
+
+    if (!toolLevels || typeof toolLevels !== 'object') {
+      return 0;
+    }
+
+    const raw = toolLevels[toolKey];
+    if (typeof raw !== 'number') {
+      return 0;
+    }
+
+    return Math.max(0, Math.floor(raw));
+  }
+
+  getEffectiveToolStats(toolKey = this.state.tools) {
+    const baseTool = TOOLS[toolKey] || TOOLS.basic;
+    const level = this.getToolUpgradeLevel(toolKey);
+    const speedBonus = baseTool.speedUpgrade || 0;
+    const energyBonus = baseTool.energyUpgrade || 0;
+
+    const speedBoost = (baseTool.speedBoost || 1) + (level * speedBonus);
+    const energyReduction = (baseTool.energyReduction || 0) + (level * energyBonus);
+
+    return {
+      ...baseTool,
+      level,
+      speedBoost,
+      energyReduction,
+    };
+  }
+
   getSeedKey(seedType) {
     return `seed_${seedType}`;
   }
@@ -488,7 +523,8 @@ export class GameEngine {
     }
 
     const irrigationDiscount = this.getSprinklerPlantingDiscount();
-    const energyCost = Math.max(1, 10 - TOOLS[tools].energyReduction - irrigationDiscount);
+    const toolStats = this.getEffectiveToolStats(tools);
+    const energyCost = Math.max(1, 10 - toolStats.energyReduction - irrigationDiscount);
     if (energy < energyCost) {
       this.notify('體力不足！', { type: 'warning' });
       return;
@@ -657,6 +693,7 @@ export class GameEngine {
         hunger: 70,
         lastFed: Date.now(),
         sick: false,
+        sicknessDays: 0,
         name: `${animal.name}${baseIndex + index + 1}`,
         productReady: 0,
       }));
@@ -847,7 +884,7 @@ export class GameEngine {
     return true;
   }
 
-  buyTool(toolType) {
+  buyTool(toolType, options = {}) {
     const { money, tools, ownedTools } = this.state;
     const tool = TOOLS[toolType];
     if (!tool) {
@@ -856,7 +893,39 @@ export class GameEngine {
     }
 
     const ownedSet = new Set(Array.isArray(ownedTools) ? ownedTools : []);
+    const wantsUpgrade = Boolean(options.upgrade);
+
     if (ownedSet.has(toolType)) {
+      if (wantsUpgrade) {
+        if (!tool.upgradeCost) {
+          this.notify('這項工具無法再升級。', { type: 'info' });
+          return;
+        }
+
+        const currentLevel = this.getToolUpgradeLevel(toolType);
+        const nextLevel = currentLevel + 1;
+        const cost = tool.upgradeCost;
+        if (money < cost) {
+          this.notify('金錢不足，暫時無法升級工具。', { type: 'error' });
+          return;
+        }
+
+        const nextSpeed = (tool.speedBoost || 1) + (tool.speedUpgrade || 0) * nextLevel;
+        const nextEnergy = (tool.energyReduction || 0) + (tool.energyUpgrade || 0) * nextLevel;
+
+        this.setters.setMoney(prev => prev - cost);
+        if (typeof this.setters.setToolLevels === 'function') {
+          this.setters.setToolLevels(prev => {
+            const previous = prev && typeof prev === 'object' ? prev : {};
+            const current = previous[toolType] || 0;
+            return { ...previous, [toolType]: current + 1 };
+          });
+        }
+        this.setters.setTools(toolType);
+        this.notify(`升級 ${tool.name} 至 Lv.${nextLevel + 1}！速度提升至 ${Math.round(nextSpeed * 100)}%，體力節省 ${Math.round(nextEnergy)}。`, { type: 'success' });
+        return;
+      }
+
       if (tools === toolType) {
         this.notify('已經裝備這項工具囉！', { type: 'info' });
       } else {
@@ -864,6 +933,11 @@ export class GameEngine {
         this.notify(`切換為 ${tool.name}。`, { type: 'success' });
       }
       this.setters.setShowToolShop(false);
+      return;
+    }
+
+    if (wantsUpgrade) {
+      this.notify('需要先購買這項工具，才能升級。', { type: 'warning' });
       return;
     }
 
@@ -881,6 +955,15 @@ export class GameEngine {
           return prevList;
         }
         return [...prevList, toolType];
+      });
+    }
+    if (typeof this.setters.setToolLevels === 'function') {
+      this.setters.setToolLevels(prev => {
+        const previous = prev && typeof prev === 'object' ? prev : {};
+        if (toolType in previous) {
+          return previous;
+        }
+        return { ...previous, [toolType]: 0 };
       });
     }
     this.setters.setShowToolShop(false);
@@ -1045,6 +1128,7 @@ export class GameEngine {
             ...a,
             sick: false,
             happiness: Math.min(100, (a.happiness ?? ANIMALS[a.type].happiness) + 25),
+            sicknessDays: 0,
           }
         : a
     ));

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -76,17 +76,63 @@ export class GameEngine {
     return 0;
   }
 
-  buySeed(seedType) {
-    const { money, marketPrices } = this.state;
-    const price = (marketPrices && marketPrices[seedType]) || CROPS[seedType].price;
+  getSeedKey(seedType) {
+    return `seed_${seedType}`;
+  }
 
-    if (money >= price) {
-      this.setters.setSelectedSupply(null);
-      this.setters.setSelectedSeed(seedType);
-      this.setters.setShowShop(false);
-      this.notify(`準備種植 ${CROPS[seedType].name}，記得找到空地！`, { type: 'success' });
+  prepareSeed(seedType) {
+    const crop = CROPS[seedType];
+    if (!crop) {
+      this.notify('找不到這種種子。', { type: 'error' });
+      return;
+    }
+
+    const { money, marketPrices, inventory } = this.state;
+    const price = (marketPrices && marketPrices[seedType]) || crop.price;
+    const seedKey = this.getSeedKey(seedType);
+    const storedSeeds = inventory?.[seedKey] || 0;
+
+    if (storedSeeds <= 0 && money < price) {
+      this.notify('金錢不足，無法準備種植。', { type: 'error' });
+      return;
+    }
+
+    this.setters.setSelectedSupply(null);
+    this.setters.setSelectedSeed(seedType);
+    this.notify(`已準備 ${crop.emoji} ${crop.name} 種子，點擊空地即可種植。`, { type: 'success' });
+  }
+
+  purchaseSeeds(seedType, quantity = 1) {
+    const crop = CROPS[seedType];
+    if (!crop) {
+      this.notify('找不到這種種子。', { type: 'error' });
+      return;
+    }
+
+    const amount = Math.max(1, Math.floor(quantity));
+    const { money, marketPrices } = this.state;
+    const price = (marketPrices && marketPrices[seedType]) || crop.price;
+    const totalCost = price * amount;
+
+    if (money < totalCost) {
+      this.notify('金錢不足，無法購買種子。', { type: 'error' });
+      return;
+    }
+
+    const seedKey = this.getSeedKey(seedType);
+    this.setters.setMoney(prev => prev - totalCost);
+    this.setters.setInventory(prev => ({
+      ...prev,
+      [seedKey]: (prev?.[seedKey] || 0) + amount,
+    }));
+    this.notify(`購買了 ${amount} 包${crop.name}種子，已存入倉庫。`, { type: 'success' });
+  }
+
+  buySeed(seedType, options) {
+    if (options && typeof options.quantity === 'number') {
+      this.purchaseSeeds(seedType, options.quantity);
     } else {
-      this.notify('金錢不足！', { type: 'error' });
+      this.prepareSeed(seedType);
     }
   }
 
@@ -272,11 +318,17 @@ export class GameEngine {
   }
 
   plantSeed(plotId) {
-    const { selectedSeed, tools, buildings, energy, money, marketPrices } = this.state;
+    const { selectedSeed, tools, buildings, energy, money, marketPrices, inventory, season, farm } = this.state;
     if (!selectedSeed) return;
 
     const price = (marketPrices && marketPrices[selectedSeed]) || CROPS[selectedSeed].price;
-    if (money < price) {
+    const seedKey = this.getSeedKey(selectedSeed);
+    const storedSeeds = inventory?.[seedKey] || 0;
+    const usingStoredSeed = storedSeeds > 0;
+    const existingPlot = Array.isArray(farm) ? farm.find(plot => plot.id === plotId) : null;
+    const isGreenhousePlot = existingPlot?.greenhouse;
+
+    if (!usingStoredSeed && money < price) {
       this.notify('金錢不足，無法種植！', { type: 'error' });
       return;
     }
@@ -301,16 +353,36 @@ export class GameEngine {
       return;
     }
 
-    this.setters.setMoney(prev => prev - price);
+    if (usingStoredSeed) {
+      this.setters.setInventory(prev => ({
+        ...prev,
+        [seedKey]: Math.max(0, (prev?.[seedKey] || 0) - 1),
+      }));
+    } else {
+      this.setters.setMoney(prev => prev - price);
+    }
+
     this.setters.setEnergy(prev => Math.max(0, prev - energyCost));
     this.setters.setExperience(prev => prev + 5);
     this.setters.setSelectedSeed(null);
     this.setters.setSelectedSupply(null);
-    this.notify(`種植了 ${CROPS[selectedSeed].name}！`, { type: 'success' });
+    const crop = CROPS[selectedSeed];
+    if (crop?.seasonBonus) {
+      const seasonBoost = isGreenhousePlot ? 1 : (crop.seasonBonus[season] ?? 1);
+      if (seasonBoost > 1.05) {
+        this.notify(`種植了 ${crop.name}！這個季節特別適合，成長速度更快！`, { type: 'success' });
+      } else if (seasonBoost < 0.9) {
+        this.notify(`種植了 ${crop.name}，但這個季節氣候不利，成長會較慢。`, { type: 'warning' });
+      } else {
+        this.notify(`種植了 ${crop.name}！`, { type: 'success' });
+      }
+    } else {
+      this.notify(`種植了 ${crop?.name || selectedSeed}！`, { type: 'success' });
+    }
   }
 
   harvestCrop(plotId) {
-    const { farm, marketPrices, buildings } = this.state;
+    const { farm, marketPrices, buildings, season } = this.state;
     const plot = farm.find(p => p.id === plotId);
     if (!plot || !plot.ready) return;
 
@@ -321,6 +393,11 @@ export class GameEngine {
     if (plot.watered) bonus *= 1.2;
     if (plot.greenhouse) bonus *= 1.5;
     if (buildings?.silo) bonus *= 1.1;
+    const cropInfo = CROPS[crop];
+    if (cropInfo?.seasonBonus) {
+      const seasonBoost = cropInfo.seasonBonus[season] ?? 1;
+      bonus *= seasonBoost;
+    }
 
     const sellPrice = Math.floor(basePrice * bonus);
 
@@ -399,6 +476,41 @@ export class GameEngine {
       this.notify(`購買了 ${animal.emoji} ${animal.name}！`, { type: 'success' });
     } else {
       this.notify('金錢不足！', { type: 'error' });
+    }
+  }
+
+  slaughterAnimal(animalId) {
+    const { animals } = this.state;
+    if (!Array.isArray(animals) || animals.length === 0) {
+      this.notify('目前沒有可處理的動物。', { type: 'info' });
+      return;
+    }
+
+    const animal = animals.find(a => a.id === animalId);
+    if (!animal) {
+      this.notify('找不到這隻動物。', { type: 'error' });
+      return;
+    }
+
+    const animalData = ANIMALS[animal.type];
+    const butcher = animalData?.butcher;
+    if (!butcher || !butcher.product) {
+      this.notify('這類動物無法進行屠宰。', { type: 'warning' });
+      return;
+    }
+
+    const product = ANIMAL_PRODUCTS[butcher.product];
+    const amount = Math.max(1, Math.floor(butcher.amount || 1));
+
+    this.setters.setAnimals(prev => prev.filter(a => a.id !== animalId));
+    if (product) {
+      this.setters.setInventory(prev => ({
+        ...prev,
+        [product.key]: (prev?.[product.key] || 0) + amount,
+      }));
+      this.notify(`已將 ${animal.name} 屠宰並獲得 ${product.name} x${amount}。`, { type: 'warning' });
+    } else {
+      this.notify(`已將 ${animal.name} 屠宰。`, { type: 'warning' });
     }
   }
 
@@ -508,25 +620,59 @@ export class GameEngine {
   }
 
   buyTool(toolType) {
-    const { money, tools } = this.state;
+    const { money, tools, ownedTools } = this.state;
     const tool = TOOLS[toolType];
-
-    if (tools === toolType) return;
-
-    if (money >= tool.price) {
-      this.setters.setMoney(prev => prev - tool.price);
-      this.setters.setTools(toolType);
-      this.setters.setShowToolShop(false);
-      this.notify(`升級工具：${tool.name}！`, { type: 'success' });
-    } else {
-      this.notify('金錢不足！', { type: 'error' });
+    if (!tool) {
+      this.notify('找不到這項工具。', { type: 'error' });
+      return;
     }
+
+    const ownedSet = new Set(Array.isArray(ownedTools) ? ownedTools : []);
+    if (ownedSet.has(toolType)) {
+      if (tools === toolType) {
+        this.notify('已經裝備這項工具囉！', { type: 'info' });
+      } else {
+        this.setters.setTools(toolType);
+        this.notify(`切換為 ${tool.name}。`, { type: 'success' });
+      }
+      this.setters.setShowToolShop(false);
+      return;
+    }
+
+    if (money < tool.price) {
+      this.notify('金錢不足！', { type: 'error' });
+      return;
+    }
+
+    this.setters.setMoney(prev => prev - tool.price);
+    this.setters.setTools(toolType);
+    if (typeof this.setters.setOwnedTools === 'function') {
+      this.setters.setOwnedTools(prev => {
+        const prevList = Array.isArray(prev) ? prev : [];
+        if (prevList.includes(toolType)) {
+          return prevList;
+        }
+        return [...prevList, toolType];
+      });
+    }
+    this.setters.setShowToolShop(false);
+    this.notify(`購買並裝備 ${tool.name}！`, { type: 'success' });
   }
 
   getInventorySaleValue(itemKey, quantity) {
     const count = quantity ?? (this.state.inventory?.[itemKey] || 0);
     if (!count || count <= 0) {
       return 0;
+    }
+
+    if (itemKey.startsWith('seed_')) {
+      const cropKey = itemKey.replace('seed_', '');
+      const crop = CROPS[cropKey];
+      if (!crop) {
+        return 0;
+      }
+      const price = (this.state.marketPrices && this.state.marketPrices[cropKey]) || crop.price;
+      return Math.max(0, Math.floor(price * count));
     }
 
     if (CROPS[itemKey]) {
@@ -586,6 +732,14 @@ export class GameEngine {
     }));
 
     this.setters.setMoney(prev => prev + saleValue);
+
+    if (itemKey.startsWith('seed_')) {
+      const cropKey = itemKey.replace('seed_', '');
+      const crop = CROPS[cropKey];
+      const label = crop ? crop.name : cropKey;
+      this.notify(`出售了 ${amountToSell} 包${label}種子，獲得 $${saleValue}！`, { type: 'success' });
+      return;
+    }
 
     const product = ANIMAL_PRODUCTS[itemKey];
     if (product) {

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -3,8 +3,14 @@ import { BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, BASE_FARM_PLOTS, MAX_FARM_PL
 
 const createDefaultInventory = () => {
   const inventory = {};
-  [...Object.keys(CROPS), ...Object.keys(ANIMAL_PRODUCTS)].forEach(key => {
+  Object.keys(CROPS).forEach(key => {
     inventory[key] = 0;
+    inventory[`seed_${key}`] = 0;
+  });
+  Object.keys(ANIMAL_PRODUCTS).forEach(key => {
+    if (!(key in inventory)) {
+      inventory[key] = 0;
+    }
   });
   return inventory;
 };
@@ -82,6 +88,7 @@ export class SaveManager {
       selectedSupply,
       animalCapacity,
       questLog,
+      ownedTools,
     } = this.state;
 
     const safeFarm = Array.isArray(farm) ? farm : [];
@@ -116,6 +123,7 @@ export class SaveManager {
       selectedSupply: selectedSupply || null,
       animalCapacity: Math.max(animalCapacity || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY),
       questLog: questLog || {},
+      ownedTools: Array.isArray(ownedTools) ? ownedTools : Array.from(ownedTools || []),
       saveTime: new Date().toISOString(),
       version: '1.1',
     };
@@ -161,6 +169,20 @@ export class SaveManager {
     this.setters.setWeatherDuration(gameState.weatherDuration || 5);
     this.setters.setInventory(withInventoryDefaults(gameState.inventory));
     this.setters.setQuestLog(gameState.questLog ? { ...gameState.questLog } : {});
+    if (typeof this.setters.setOwnedTools === 'function') {
+      const owned = Array.isArray(gameState.ownedTools)
+        ? gameState.ownedTools
+        : (typeof gameState.tools === 'string' ? [gameState.tools] : []);
+      const baseTool = gameState.tools || 'basic';
+      const normalizedOwned = owned.length > 0 ? [...owned] : [baseTool];
+      if (!normalizedOwned.includes(baseTool)) {
+        normalizedOwned.push(baseTool);
+      }
+      if (!normalizedOwned.includes('basic')) {
+        normalizedOwned.unshift('basic');
+      }
+      this.setters.setOwnedTools(normalizedOwned);
+    }
     const sanitizedFarm = Array.isArray(gameState.farm)
       ? gameState.farm.map((plot, index) => ({
           id: plot.id ?? index,

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -88,6 +88,7 @@ export class SaveManager {
       selectedSupply,
       animalCapacity,
       questLog,
+      dynamicQuests,
       ownedTools,
     } = this.state;
 
@@ -123,6 +124,7 @@ export class SaveManager {
       selectedSupply: selectedSupply || null,
       animalCapacity: Math.max(animalCapacity || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY),
       questLog: questLog || {},
+      dynamicQuests: dynamicQuests || {},
       ownedTools: Array.isArray(ownedTools) ? ownedTools : Array.from(ownedTools || []),
       saveTime: new Date().toISOString(),
       version: '1.1',
@@ -169,6 +171,12 @@ export class SaveManager {
     this.setters.setWeatherDuration(gameState.weatherDuration || 5);
     this.setters.setInventory(withInventoryDefaults(gameState.inventory));
     this.setters.setQuestLog(gameState.questLog ? { ...gameState.questLog } : {});
+    if (typeof this.setters.setDynamicQuests === 'function') {
+      const dynamic = gameState.dynamicQuests && typeof gameState.dynamicQuests === 'object'
+        ? { ...gameState.dynamicQuests }
+        : {};
+      this.setters.setDynamicQuests(dynamic);
+    }
     if (typeof this.setters.setOwnedTools === 'function') {
       const owned = Array.isArray(gameState.ownedTools)
         ? gameState.ownedTools

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -81,6 +81,7 @@ export class SaveManager {
       marketPrices,
       selectedSupply,
       animalCapacity,
+      questLog,
     } = this.state;
 
     const safeFarm = Array.isArray(farm) ? farm : [];
@@ -114,6 +115,7 @@ export class SaveManager {
       marketPrices,
       selectedSupply: selectedSupply || null,
       animalCapacity: Math.max(animalCapacity || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY),
+      questLog: questLog || {},
       saveTime: new Date().toISOString(),
       version: '1.1',
     };
@@ -158,6 +160,7 @@ export class SaveManager {
     this.setters.setWeather(gameState.weather);
     this.setters.setWeatherDuration(gameState.weatherDuration || 5);
     this.setters.setInventory(withInventoryDefaults(gameState.inventory));
+    this.setters.setQuestLog(gameState.questLog ? { ...gameState.questLog } : {});
     const sanitizedFarm = Array.isArray(gameState.farm)
       ? gameState.farm.map((plot, index) => ({
           id: plot.id ?? index,

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -17,6 +17,8 @@ const createDefaultFarm = () =>
     fertilized: false,
     greenhouse: false,
     pest: false,
+    pestDays: 0,
+    ready: false,
   }));
 
 const createDefaultSupplies = () => ({
@@ -131,7 +133,20 @@ export class SaveManager {
     this.setters.setWeather(gameState.weather);
     this.setters.setWeatherDuration(gameState.weatherDuration || 5);
     this.setters.setInventory(gameState.inventory || createDefaultInventory());
-    this.setters.setFarm(Array.isArray(gameState.farm) ? gameState.farm : createDefaultFarm());
+    const sanitizedFarm = Array.isArray(gameState.farm)
+      ? gameState.farm.map((plot, index) => ({
+          id: plot.id ?? index,
+          crop: plot.crop ?? null,
+          plantTime: plot.plantTime ?? null,
+          watered: plot.crop ? Boolean(plot.watered) : false,
+          fertilized: Boolean(plot.fertilized),
+          greenhouse: Boolean(plot.greenhouse),
+          pest: Boolean(plot.pest),
+          pestDays: plot.pest ? (plot.pestDays ?? 1) : 0,
+          ready: plot.crop ? Boolean(plot.ready) : false,
+        }))
+      : createDefaultFarm();
+    this.setters.setFarm(sanitizedFarm);
     this.setters.setFarmSupplies(gameState.farmSupplies || createDefaultSupplies());
     const sanitizedAnimals = Array.isArray(gameState.animals)
       ? gameState.animals.map(animal => ({
@@ -142,7 +157,12 @@ export class SaveManager {
         }))
       : [];
     this.setters.setAnimals(sanitizedAnimals);
-    this.setters.setBuildings(gameState.buildings || {});
+    const normalizedBuildings = { ...(gameState.buildings || {}) };
+    if (normalizedBuildings.well) {
+      normalizedBuildings.sprinkler = true;
+      delete normalizedBuildings.well;
+    }
+    this.setters.setBuildings(normalizedBuildings);
     this.setters.setTools(gameState.tools || 'basic');
     this.setters.setCompletedAchievements(new Set(gameState.completedAchievements || []));
     this.setters.setDailyStats(gameState.dailyStats || []);

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -1,5 +1,5 @@
 import { ANIMALS, CROPS, ANIMAL_PRODUCTS } from '../data/GameCatalog';
-import { BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, BASE_FARM_PLOTS, MAX_FARM_PLOTS } from './GameEngine';
+import { BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BUILDING_UPGRADES } from './GameEngine';
 
 const createDefaultInventory = () => {
   const inventory = {};
@@ -213,9 +213,29 @@ export class SaveManager {
 
     let normalizedBuildings = { ...(gameState.buildings || {}) };
     if (normalizedBuildings.well) {
-      normalizedBuildings.sprinkler = true;
+      normalizedBuildings.sprinkler = Math.max(normalizedBuildings.sprinkler || 0, 1);
       delete normalizedBuildings.well;
     }
+
+    Object.entries(BUILDING_UPGRADES).forEach(([key, upgrades]) => {
+      if (!Array.isArray(upgrades) || upgrades.length === 0) {
+        return;
+      }
+
+      const raw = normalizedBuildings[key];
+      if (raw === undefined || raw === null || raw === false) {
+        delete normalizedBuildings[key];
+        return;
+      }
+
+      const maxLevel = upgrades[upgrades.length - 1].level;
+      if (typeof raw === 'number') {
+        const level = Math.max(1, Math.floor(raw));
+        normalizedBuildings[key] = Math.min(level, maxLevel);
+      } else if (raw === true) {
+        normalizedBuildings[key] = upgrades[0].level;
+      }
+    });
 
     const rawGreenhouse = normalizedBuildings.greenhouse;
     let desiredGreenhouseCount = 0;

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -1,15 +1,29 @@
-import { ANIMALS, CROPS } from '../data/GameCatalog';
+import { ANIMALS, CROPS, ANIMAL_PRODUCTS } from '../data/GameCatalog';
+import { BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, BASE_FARM_PLOTS, MAX_FARM_PLOTS } from './GameEngine';
 
 const createDefaultInventory = () => {
   const inventory = {};
-  Object.keys(CROPS).forEach(key => {
+  [...Object.keys(CROPS), ...Object.keys(ANIMAL_PRODUCTS)].forEach(key => {
     inventory[key] = 0;
   });
   return inventory;
 };
 
-const createDefaultFarm = () =>
-  Array.from({ length: 25 }, (_, index) => ({
+const withInventoryDefaults = (inventory) => {
+  const defaults = createDefaultInventory();
+  if (!inventory) {
+    return defaults;
+  }
+
+  const sanitized = { ...defaults };
+  Object.entries(inventory).forEach(([key, value]) => {
+    sanitized[key] = typeof value === 'number' ? value : defaults[key] || 0;
+  });
+  return sanitized;
+};
+
+const createDefaultFarm = (length = BASE_FARM_PLOTS) =>
+  Array.from({ length }, (_, index) => ({
     id: index,
     crop: null,
     plantTime: null,
@@ -55,7 +69,7 @@ export class SaveManager {
       season,
       weather,
       weatherDuration,
-      inventory,
+      inventory: rawInventory,
       farm,
       farmSupplies,
       animals,
@@ -66,6 +80,7 @@ export class SaveManager {
       automation,
       marketPrices,
       selectedSupply,
+      animalCapacity,
     } = this.state;
 
     return {
@@ -78,7 +93,7 @@ export class SaveManager {
       season,
       weather,
       weatherDuration,
-      inventory,
+      inventory: withInventoryDefaults(rawInventory),
       farm,
       farmSupplies,
       animals,
@@ -89,8 +104,9 @@ export class SaveManager {
       automation,
       marketPrices,
       selectedSupply: selectedSupply || null,
+      animalCapacity: Math.max(animalCapacity || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY),
       saveTime: new Date().toISOString(),
-      version: '1.0',
+      version: '1.1',
     };
   }
 
@@ -132,7 +148,7 @@ export class SaveManager {
     this.setters.setSeason(gameState.season);
     this.setters.setWeather(gameState.weather);
     this.setters.setWeatherDuration(gameState.weatherDuration || 5);
-    this.setters.setInventory(gameState.inventory || createDefaultInventory());
+    this.setters.setInventory(withInventoryDefaults(gameState.inventory));
     const sanitizedFarm = Array.isArray(gameState.farm)
       ? gameState.farm.map((plot, index) => ({
           id: plot.id ?? index,
@@ -146,7 +162,26 @@ export class SaveManager {
           ready: plot.crop ? Boolean(plot.ready) : false,
         }))
       : createDefaultFarm();
-    this.setters.setFarm(sanitizedFarm);
+
+    const minPlots = Math.max(BASE_FARM_PLOTS, sanitizedFarm.length);
+    let normalizedFarm = sanitizedFarm;
+    if (sanitizedFarm.length < minPlots) {
+      const needed = minPlots - sanitizedFarm.length;
+      const startId = sanitizedFarm.reduce((max, plot) => Math.max(max, plot.id ?? -1), -1) + 1;
+      const additional = createDefaultFarm(needed).map((plot, idx) => ({
+        ...plot,
+        id: startId + idx,
+      }));
+      normalizedFarm = [...sanitizedFarm, ...additional];
+    } else if (sanitizedFarm.length > MAX_FARM_PLOTS) {
+      normalizedFarm = sanitizedFarm.slice(0, MAX_FARM_PLOTS);
+    }
+
+    const hasGreenhouse = Boolean(gameState.buildings?.greenhouse);
+    if (hasGreenhouse) {
+      normalizedFarm = normalizedFarm.map(plot => ({ ...plot, greenhouse: true }));
+    }
+    this.setters.setFarm(normalizedFarm);
     this.setters.setFarmSupplies(gameState.farmSupplies || createDefaultSupplies());
     const sanitizedAnimals = Array.isArray(gameState.animals)
       ? gameState.animals.map(animal => ({
@@ -157,6 +192,11 @@ export class SaveManager {
         }))
       : [];
     this.setters.setAnimals(sanitizedAnimals);
+    const requiredCapacity = Math.max(sanitizedAnimals.length, BASE_ANIMAL_CAPACITY);
+    if (typeof this.setters.setAnimalCapacity === 'function') {
+      const desiredCapacity = Math.max(gameState.animalCapacity || BASE_ANIMAL_CAPACITY, requiredCapacity);
+      this.setters.setAnimalCapacity(Math.min(desiredCapacity, MAX_ANIMAL_CAPACITY));
+    }
     const normalizedBuildings = { ...(gameState.buildings || {}) };
     if (normalizedBuildings.well) {
       normalizedBuildings.sprinkler = true;

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -90,6 +90,7 @@ export class SaveManager {
       questLog,
       dynamicQuests,
       ownedTools,
+      toolLevels,
     } = this.state;
 
     const safeFarm = Array.isArray(farm) ? farm : [];
@@ -126,6 +127,7 @@ export class SaveManager {
       questLog: questLog || {},
       dynamicQuests: dynamicQuests || {},
       ownedTools: Array.isArray(ownedTools) ? ownedTools : Array.from(ownedTools || []),
+      toolLevels: toolLevels && typeof toolLevels === 'object' ? { ...toolLevels } : {},
       saveTime: new Date().toISOString(),
       version: '1.1',
     };
@@ -191,6 +193,15 @@ export class SaveManager {
         normalizedOwned.unshift('basic');
       }
       this.setters.setOwnedTools(normalizedOwned);
+    }
+    if (typeof this.setters.setToolLevels === 'function') {
+      const levels = gameState.toolLevels && typeof gameState.toolLevels === 'object'
+        ? Object.entries(gameState.toolLevels).reduce((acc, [key, value]) => {
+            acc[key] = Math.max(0, Math.floor(value));
+            return acc;
+          }, {})
+        : {};
+      this.setters.setToolLevels(levels);
     }
     const sanitizedFarm = Array.isArray(gameState.farm)
       ? gameState.farm.map((plot, index) => ({
@@ -291,6 +302,7 @@ export class SaveManager {
           hunger: animal.hunger ?? 60,
           sick: animal.sick ?? false,
           productReady: Math.max(0, Math.floor(animal.productReady || 0)),
+          sicknessDays: Math.max(0, Math.floor(animal.sicknessDays ?? (animal.sick ? 1 : 0))),
         }))
       : [];
     this.setters.setAnimals(sanitizedAnimals);

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -208,6 +208,12 @@ export class SaveManager {
     this.setters.setDailyStats(gameState.dailyStats || []);
     this.setters.setAutomation(gameState.automation || { autoWater: false, autoHarvest: false });
     this.setters.setMarketPrices(gameState.marketPrices || {});
+    if (typeof this.setters.setPreviousMarketPrices === 'function') {
+      this.setters.setPreviousMarketPrices(gameState.marketPrices || {});
+    }
+    if (typeof this.setters.setMarketUpdateTime === 'function') {
+      this.setters.setMarketUpdateTime(Date.now());
+    }
     this.setters.setSelectedSupply(gameState.selectedSupply || null);
   }
 

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -169,7 +169,8 @@ export class SaveManager {
     this.setters.setSeason(gameState.season);
     this.setters.setWeather(gameState.weather);
     this.setters.setWeatherDuration(gameState.weatherDuration || 5);
-    this.setters.setInventory(withInventoryDefaults(gameState.inventory));
+    const normalizedInventory = withInventoryDefaults(gameState.inventory);
+    this.setters.setInventory(normalizedInventory);
     this.setters.setQuestLog(gameState.questLog ? { ...gameState.questLog } : {});
     if (typeof this.setters.setDynamicQuests === 'function') {
       const dynamic = gameState.dynamicQuests && typeof gameState.dynamicQuests === 'object'
@@ -276,13 +277,20 @@ export class SaveManager {
     }
 
     this.setters.setFarm(normalizedFarm);
-    this.setters.setFarmSupplies(gameState.farmSupplies || createDefaultSupplies());
+    const baseSupplies = { ...createDefaultSupplies(), ...(gameState.farmSupplies || {}) };
+    Object.entries(normalizedInventory).forEach(([key, value]) => {
+      if (key.startsWith('seed_')) {
+        baseSupplies[key] = value;
+      }
+    });
+    this.setters.setFarmSupplies(baseSupplies);
     const sanitizedAnimals = Array.isArray(gameState.animals)
       ? gameState.animals.map(animal => ({
           ...animal,
           happiness: animal.happiness ?? ANIMALS[animal.type]?.happiness ?? 50,
           hunger: animal.hunger ?? 60,
           sick: animal.sick ?? false,
+          productReady: Math.max(0, Math.floor(animal.productReady || 0)),
         }))
       : [];
     this.setters.setAnimals(sanitizedAnimals);

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -19,6 +19,12 @@ const createDefaultFarm = () =>
     pest: false,
   }));
 
+const createDefaultSupplies = () => ({
+  fertilizer: 0,
+  pesticide: 0,
+  medicine: 0,
+});
+
 export class SaveManager {
   constructor({ stateRef, setters, notifier }) {
     this.stateRef = stateRef;
@@ -49,6 +55,7 @@ export class SaveManager {
       weatherDuration,
       inventory,
       farm,
+      farmSupplies,
       animals,
       buildings,
       tools,
@@ -56,6 +63,7 @@ export class SaveManager {
       dailyStats,
       automation,
       marketPrices,
+      selectedSupply,
     } = this.state;
 
     return {
@@ -70,6 +78,7 @@ export class SaveManager {
       weatherDuration,
       inventory,
       farm,
+      farmSupplies,
       animals,
       buildings,
       tools,
@@ -77,6 +86,7 @@ export class SaveManager {
       dailyStats,
       automation,
       marketPrices,
+      selectedSupply: selectedSupply || null,
       saveTime: new Date().toISOString(),
       version: '1.0',
     };
@@ -122,11 +132,13 @@ export class SaveManager {
     this.setters.setWeatherDuration(gameState.weatherDuration || 5);
     this.setters.setInventory(gameState.inventory || createDefaultInventory());
     this.setters.setFarm(Array.isArray(gameState.farm) ? gameState.farm : createDefaultFarm());
+    this.setters.setFarmSupplies(gameState.farmSupplies || createDefaultSupplies());
     const sanitizedAnimals = Array.isArray(gameState.animals)
       ? gameState.animals.map(animal => ({
           ...animal,
           happiness: animal.happiness ?? ANIMALS[animal.type]?.happiness ?? 50,
           hunger: animal.hunger ?? 60,
+          sick: animal.sick ?? false,
         }))
       : [];
     this.setters.setAnimals(sanitizedAnimals);
@@ -136,6 +148,7 @@ export class SaveManager {
     this.setters.setDailyStats(gameState.dailyStats || []);
     this.setters.setAutomation(gameState.automation || { autoWater: false, autoHarvest: false });
     this.setters.setMarketPrices(gameState.marketPrices || {});
+    this.setters.setSelectedSupply(gameState.selectedSupply || null);
   }
 
   exportSave() {

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -83,6 +83,15 @@ export class SaveManager {
       animalCapacity,
     } = this.state;
 
+    const safeFarm = Array.isArray(farm) ? farm : [];
+    const greenhouseCount = safeFarm.reduce((count, plot) => count + (plot.greenhouse ? 1 : 0), 0);
+    const buildingSnapshot = { ...(buildings || {}) };
+    if (greenhouseCount > 0) {
+      buildingSnapshot.greenhouse = greenhouseCount;
+    } else if (buildingSnapshot.greenhouse) {
+      delete buildingSnapshot.greenhouse;
+    }
+
     return {
       money,
       energy,
@@ -97,7 +106,7 @@ export class SaveManager {
       farm,
       farmSupplies,
       animals,
-      buildings,
+      buildings: buildingSnapshot,
       tools,
       completedAchievements: Array.from(completedAchievements || []),
       dailyStats,
@@ -177,10 +186,42 @@ export class SaveManager {
       normalizedFarm = sanitizedFarm.slice(0, MAX_FARM_PLOTS);
     }
 
-    const hasGreenhouse = Boolean(gameState.buildings?.greenhouse);
-    if (hasGreenhouse) {
-      normalizedFarm = normalizedFarm.map(plot => ({ ...plot, greenhouse: true }));
+    let normalizedBuildings = { ...(gameState.buildings || {}) };
+    if (normalizedBuildings.well) {
+      normalizedBuildings.sprinkler = true;
+      delete normalizedBuildings.well;
     }
+
+    const rawGreenhouse = normalizedBuildings.greenhouse;
+    let desiredGreenhouseCount = 0;
+    if (typeof rawGreenhouse === 'number') {
+      desiredGreenhouseCount = Math.max(0, Math.floor(rawGreenhouse));
+    } else if (rawGreenhouse) {
+      desiredGreenhouseCount = normalizedFarm.length;
+    }
+
+    let actualGreenhouseCount = normalizedFarm.reduce((count, plot) => count + (plot.greenhouse ? 1 : 0), 0);
+    if (desiredGreenhouseCount > actualGreenhouseCount) {
+      let remaining = desiredGreenhouseCount - actualGreenhouseCount;
+      normalizedFarm = normalizedFarm.map(plot => {
+        if (!plot.greenhouse && remaining > 0) {
+          remaining -= 1;
+          return { ...plot, greenhouse: true };
+        }
+        return plot;
+      });
+      actualGreenhouseCount = normalizedFarm.reduce((count, plot) => count + (plot.greenhouse ? 1 : 0), 0);
+      desiredGreenhouseCount = actualGreenhouseCount;
+    } else if (desiredGreenhouseCount === 0 && actualGreenhouseCount > 0) {
+      desiredGreenhouseCount = actualGreenhouseCount;
+    }
+
+    if (desiredGreenhouseCount > 0) {
+      normalizedBuildings.greenhouse = desiredGreenhouseCount;
+    } else {
+      delete normalizedBuildings.greenhouse;
+    }
+
     this.setters.setFarm(normalizedFarm);
     this.setters.setFarmSupplies(gameState.farmSupplies || createDefaultSupplies());
     const sanitizedAnimals = Array.isArray(gameState.animals)
@@ -197,11 +238,6 @@ export class SaveManager {
       const desiredCapacity = Math.max(gameState.animalCapacity || BASE_ANIMAL_CAPACITY, requiredCapacity);
       this.setters.setAnimalCapacity(Math.min(desiredCapacity, MAX_ANIMAL_CAPACITY));
     }
-    const normalizedBuildings = { ...(gameState.buildings || {}) };
-    if (normalizedBuildings.well) {
-      normalizedBuildings.sprinkler = true;
-      delete normalizedBuildings.well;
-    }
     this.setters.setBuildings(normalizedBuildings);
     this.setters.setTools(gameState.tools || 'basic');
     this.setters.setCompletedAchievements(new Set(gameState.completedAchievements || []));
@@ -215,6 +251,9 @@ export class SaveManager {
       this.setters.setMarketUpdateTime(Date.now());
     }
     this.setters.setSelectedSupply(gameState.selectedSupply || null);
+    if (typeof this.setters.setPendingGreenhousePlacement === 'function') {
+      this.setters.setPendingGreenhousePlacement(false);
+    }
   }
 
   exportSave() {

--- a/src/game/quests/QuestManager.js
+++ b/src/game/quests/QuestManager.js
@@ -1,0 +1,395 @@
+import { CROPS, ANIMAL_PRODUCTS, FARM_SUPPLIES, NPCS } from '../data/GameCatalog';
+
+const DYNAMIC_QUEST_SLOTS = 3;
+
+const randomBetween = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
+const pickOne = (list) => list[Math.floor(Math.random() * list.length)];
+
+export class QuestManager {
+  constructor({ stateRef, setQuestLog, setDynamicQuests, setInventory, setMoney, notifier }) {
+    this.stateRef = stateRef;
+    this.setQuestLog = setQuestLog;
+    this.setDynamicQuests = setDynamicQuests;
+    this.setInventory = setInventory;
+    this.setMoney = setMoney;
+    this.notifier = notifier;
+  }
+
+  buildQuestDefinitions(dynamicQuests = {}) {
+    const map = {};
+
+    NPCS.forEach(npc => {
+      (npc.quests || []).forEach(quest => {
+        if (quest?.id) {
+          map[quest.id] = { ...quest, npcName: npc.name };
+        }
+      });
+    });
+
+    Object.entries(dynamicQuests || {}).forEach(([questId, quest]) => {
+      if (questId && quest) {
+        map[questId] = quest;
+      }
+    });
+
+    return map;
+  }
+
+  getQuestTargetLabel(quest) {
+    if (!quest?.target) {
+      return '目標';
+    }
+
+    if (CROPS[quest.target]) {
+      const crop = CROPS[quest.target];
+      return `${crop.emoji} ${crop.name}`;
+    }
+
+    if (ANIMAL_PRODUCTS[quest.target]) {
+      const product = ANIMAL_PRODUCTS[quest.target];
+      return `${product.emoji} ${product.name}`;
+    }
+
+    if (FARM_SUPPLIES[quest.target]) {
+      const supply = FARM_SUPPLIES[quest.target];
+      return `${supply.emoji} ${supply.name}`;
+    }
+
+    return quest.target;
+  }
+
+  refreshDaily(currentDay) {
+    const existingDynamic = this.stateRef.current.dynamicQuests || {};
+    const existingLog = this.stateRef.current.questLog || {};
+
+    const preserved = {};
+    Object.entries(existingDynamic).forEach(([id, quest]) => {
+      const status = existingLog?.[id]?.status;
+      if (status === 'accepted' || status === 'ready') {
+        preserved[id] = quest;
+      }
+    });
+
+    const questGivers = ['商會佈告欄', '旅行商人', '鄰村里長', '合作社代表', '冒險者公會'];
+    const deliverTargets = [...Object.keys(CROPS), ...Object.keys(ANIMAL_PRODUCTS)];
+    const harvestTargets = Object.keys(CROPS);
+    const sellTargets = Object.keys(CROPS);
+
+    const usedIds = new Set(Object.keys(preserved));
+    const createQuestId = (slot) => {
+      let attempt = 0;
+      let id;
+      do {
+        id = `daily_${currentDay}_${slot}_${Math.random().toString(36).slice(2, 6)}`;
+        attempt += 1;
+      } while (usedIds.has(id) && attempt < 5);
+      usedIds.add(id);
+      return id;
+    };
+
+    const buildQuest = (slot) => {
+      const giver = pickOne(questGivers);
+      const questTypes = ['deliver', 'harvest', 'sell', 'pestClear'];
+      const type = pickOne(questTypes);
+      const questId = createQuestId(slot);
+
+      if (type === 'deliver' && deliverTargets.length > 0) {
+        const target = pickOne(deliverTargets);
+        const product = ANIMAL_PRODUCTS[target];
+        const crop = CROPS[target];
+        const isProduct = Boolean(product);
+        const label = isProduct
+          ? `${product.emoji} ${product.name}`
+          : `${crop.emoji} ${crop.name}`;
+        const basePrice = isProduct ? product.basePrice : crop.sellPrice;
+        const count = isProduct ? randomBetween(4, 12) : randomBetween(18, 45);
+        const reward = Math.max(150, Math.floor(basePrice * count * (isProduct ? 1.9 : 1.5)));
+        return {
+          id: questId,
+          type: 'deliver',
+          target,
+          count,
+          reward,
+          description: `${giver} 需要 ${count} 份${label}，協助供貨即可獲得酬勞。`,
+          npcName: giver,
+        };
+      }
+
+      if (type === 'harvest' && harvestTargets.length > 0) {
+        const target = pickOne(harvestTargets);
+        const crop = CROPS[target];
+        const count = randomBetween(10, 28);
+        const reward = Math.max(160, Math.floor(crop.sellPrice * count * (1.4 + Math.random() * 0.5)));
+        return {
+          id: questId,
+          type: 'harvest',
+          target,
+          count,
+          reward,
+          description: `${giver} 正準備市集，收成 ${count} 份${crop.emoji} ${crop.name} 就能領取獎金。`,
+          npcName: giver,
+        };
+      }
+
+      if (type === 'sell' && sellTargets.length > 0) {
+        const target = pickOne(sellTargets);
+        const crop = CROPS[target];
+        const count = randomBetween(15, 35);
+        const reward = Math.max(200, Math.floor(crop.sellPrice * count * (1.55 + Math.random() * 0.45)));
+        return {
+          id: questId,
+          type: 'sell',
+          target,
+          count,
+          reward,
+          description: `${giver} 想炒熱 ${crop.emoji} ${crop.name} 的行情，賣出 ${count} 份即可分紅。`,
+          npcName: giver,
+        };
+      }
+
+      const pestCount = randomBetween(3, 6);
+      const reward = randomBetween(180, 320);
+      return {
+        id: questId,
+        type: 'pestClear',
+        count: pestCount,
+        reward,
+        description: `${giver} 報告蟲害，協助處理 ${pestCount} 塊農地的害蟲。`,
+        npcName: giver,
+      };
+    };
+
+    const combined = { ...preserved };
+    let slotIndex = 0;
+    while (Object.keys(combined).length < DYNAMIC_QUEST_SLOTS) {
+      const quest = buildQuest(slotIndex);
+      combined[quest.id] = quest;
+      slotIndex += 1;
+    }
+
+    this.setDynamicQuests(combined);
+    this.setQuestLog(prev => {
+      if (!prev) {
+        return prev;
+      }
+      const next = { ...prev };
+      Object.keys(prev).forEach(id => {
+        if (id.startsWith('daily_') && !combined[id]) {
+          delete next[id];
+        }
+      });
+      return next;
+    });
+  }
+
+  recordEvent(event, questDefinitions) {
+    if (!event?.type) {
+      return;
+    }
+
+    this.setQuestLog(prev => {
+      if (!prev || Object.keys(prev).length === 0) {
+        return prev;
+      }
+
+      let mutated = false;
+      const next = { ...prev };
+
+      Object.entries(prev).forEach(([questId, entry]) => {
+        if (!entry || (entry.status !== 'accepted' && entry.status !== 'ready')) {
+          return;
+        }
+
+        const quest = questDefinitions[questId];
+        if (!quest) {
+          return;
+        }
+
+        const required = quest.count ?? 0;
+        const currentProgress = entry.progress ?? 0;
+        let updatedEntry = entry;
+
+        switch (quest.type) {
+          case 'harvest':
+            if (event.type === 'harvest' && event.crop === quest.target) {
+              const newProgress = Math.min(required, currentProgress + (event.amount ?? 1));
+              if (newProgress !== currentProgress || entry.status !== 'ready') {
+                updatedEntry = { ...entry, progress: newProgress };
+                if (required > 0 && newProgress >= required) {
+                  updatedEntry.status = 'ready';
+                }
+              }
+            }
+            break;
+          case 'sell':
+            if (event.type === 'sell' && event.crop === quest.target) {
+              const newProgress = Math.min(required, currentProgress + (event.amount ?? 1));
+              if (newProgress !== currentProgress || entry.status !== 'ready') {
+                updatedEntry = { ...entry, progress: newProgress };
+                if (required > 0 && newProgress >= required) {
+                  updatedEntry.status = 'ready';
+                }
+              }
+            }
+            break;
+          case 'pestClear':
+            if (event.type === 'pestClear') {
+              const newProgress = Math.min(required, currentProgress + (event.amount ?? 1));
+              if (newProgress !== currentProgress || entry.status !== 'ready') {
+                updatedEntry = { ...entry, progress: newProgress };
+                if (required > 0 && newProgress >= required) {
+                  updatedEntry.status = 'ready';
+                }
+              }
+            }
+            break;
+          default:
+            break;
+        }
+
+        if (updatedEntry !== entry) {
+          next[questId] = updatedEntry;
+          mutated = true;
+        }
+      });
+
+      return mutated ? next : prev;
+    });
+  }
+
+  acceptQuest(questId, questDefinitions, questLog, day) {
+    const quest = questDefinitions[questId];
+    if (!quest) {
+      return;
+    }
+
+    const existing = questLog[questId];
+    if (existing?.status === 'accepted' || existing?.status === 'ready') {
+      this.notifier('任務已在進行中！', { type: 'info' });
+      return;
+    }
+    if (existing?.status === 'completed') {
+      this.notifier('這項任務已經完成過囉！', { type: 'info' });
+      return;
+    }
+
+    this.setQuestLog(prev => ({
+      ...prev,
+      [questId]: {
+        status: 'accepted',
+        progress: 0,
+        acceptedDay: day,
+      },
+    }));
+    this.notifier(`📜 接下任務：「${quest.description}」`, { type: 'info' });
+  }
+
+  deliverQuest(questId, questDefinitions, questLog, inventory, day) {
+    const quest = questDefinitions[questId];
+    if (!quest || quest.type !== 'deliver') {
+      return;
+    }
+
+    const entry = questLog[questId];
+    if (!entry || entry.status !== 'accepted') {
+      if (entry?.status === 'completed') {
+        this.notifier('任務已經交付完成。', { type: 'info' });
+      } else {
+        this.notifier('請先接受任務再進行交付。', { type: 'warning' });
+      }
+      return;
+    }
+
+    const needCount = quest.count ?? 0;
+    const available = inventory?.[quest.target] ?? 0;
+    if (available < needCount) {
+      this.notifier('庫存不足，無法完成交付。', { type: 'warning' });
+      return;
+    }
+
+    this.setInventory(prev => ({
+      ...prev,
+      [quest.target]: Math.max(0, (prev?.[quest.target] || 0) - needCount),
+    }));
+    this.setMoney(prev => prev + (quest.reward ?? 0));
+    this.setQuestLog(prev => ({
+      ...prev,
+      [questId]: {
+        ...prev[questId],
+        status: 'completed',
+        progress: needCount,
+        completedDay: day,
+      },
+    }));
+
+    const targetLabel = this.getQuestTargetLabel(quest);
+    this.notifier(`🎁 已交付 ${needCount} 份${targetLabel}，獲得 $${quest.reward}！`, { type: 'success' });
+  }
+
+  claimQuestReward(questId, questDefinitions, questLog, day) {
+    const quest = questDefinitions[questId];
+    if (!quest) {
+      return;
+    }
+
+    const entry = questLog[questId];
+    if (!entry) {
+      this.notifier('請先接受任務！', { type: 'info' });
+      return;
+    }
+
+    if (entry.status !== 'ready') {
+      if (entry.status === 'completed') {
+        this.notifier('任務獎勵已經領取過了。', { type: 'info' });
+      } else {
+        this.notifier('仍未達成任務要求，持續加油！', { type: 'warning' });
+      }
+      return;
+    }
+
+    this.setMoney(prev => prev + (quest.reward ?? 0));
+    this.setQuestLog(prev => ({
+      ...prev,
+      [questId]: {
+        ...prev[questId],
+        status: 'completed',
+        progress: quest.count ?? prev[questId]?.progress ?? 0,
+        completedDay: day,
+      },
+    }));
+    this.notifier(`💰 領取任務獎勵 $${quest.reward}！`, { type: 'success' });
+  }
+
+  getActiveQuests(questDefinitions, questLog, inventory) {
+    if (!questLog) {
+      return [];
+    }
+
+    return Object.entries(questLog)
+      .map(([questId, entry]) => {
+        const quest = questDefinitions[questId];
+        if (!quest || entry.status === 'completed') {
+          return null;
+        }
+
+        const required = quest.count ?? 0;
+        const inventoryCount = quest.type === 'deliver' ? (inventory?.[quest.target] ?? 0) : null;
+        const progress = quest.type === 'deliver'
+          ? Math.min(required, inventoryCount ?? 0)
+          : Math.min(required, entry.progress ?? 0);
+        const ready = entry.status === 'ready'
+          || (quest.type === 'deliver' && entry.status === 'accepted' && inventoryCount != null && inventoryCount >= required);
+
+        return {
+          id: questId,
+          quest,
+          entry,
+          required,
+          progress,
+          ready,
+          inventoryCount,
+        };
+      })
+      .filter(Boolean);
+  }
+}

--- a/src/game/state/InventoryState.js
+++ b/src/game/state/InventoryState.js
@@ -1,0 +1,40 @@
+import { CROPS, ANIMAL_PRODUCTS } from '../data/GameCatalog';
+
+const CROP_METADATA = Object.fromEntries(
+  Object.entries(CROPS).map(([key, crop]) => [
+    key,
+    { name: crop.name, emoji: crop.emoji, type: 'crop', cropKey: key },
+  ]),
+);
+
+const SEED_METADATA = Object.fromEntries(
+  Object.entries(CROPS).map(([key, crop]) => [
+    `seed_${key}`,
+    { name: `${crop.name}種子`, emoji: crop.emoji, type: 'seed', cropKey: key },
+  ]),
+);
+
+const PRODUCT_METADATA = Object.fromEntries(
+  Object.entries(ANIMAL_PRODUCTS).map(([key, product]) => [
+    key,
+    { name: product.name, emoji: product.emoji, type: 'product', animal: product.animal },
+  ]),
+);
+
+export const INVENTORY_METADATA = {
+  ...CROP_METADATA,
+  ...PRODUCT_METADATA,
+  ...SEED_METADATA,
+};
+
+export const INVENTORY_ORDER = Object.keys(INVENTORY_METADATA);
+
+export const createInitialInventory = () => {
+  const base = {};
+  INVENTORY_ORDER.forEach(key => {
+    base[key] = 0;
+  });
+  return base;
+};
+
+export const getInventoryMetadata = (key) => INVENTORY_METADATA[key] || null;


### PR DESCRIPTION
## Summary
- introduce farm supplies catalog entries and persist them with saves
- add daily pest outbreaks, fertilizer boosts, and animal sickness handling with new UI for supplies and treatments
- extend the game engine with supply selection, application, and animal treatment actions plus adjust build script for cross-platform compatibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d260a873048329b16910a70d645fdc