### PR TITLE
Fix invalid crop data blocking planting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -618,7 +618,7 @@ const FarmGame = () => {
         
         switch (achievement.id) {
           case 'firstPlant':
-            unlocked = farm.some(plot => plot.crop);
+            unlocked = farm.some(plot => plot.crop && CROPS[plot.crop]);
             break;
           case 'richFarmer':
             unlocked = money >= 10000;
@@ -941,14 +941,28 @@ const FarmGame = () => {
             const nextFarm = prevFarm.map(plot => {
               let updatedPlot = plot;
 
-              if (plot.crop) {
-                const originalCrop = CROPS[plot.crop];
+              const originalCrop = plot?.crop ? CROPS[plot.crop] : null;
+
+              if (plot?.crop && !originalCrop) {
+                const clearedPlot = {
+                  ...plot,
+                  crop: null,
+                  plantTime: null,
+                  watered: false,
+                  fertilized: false,
+                  pest: false,
+                  pestDays: 0,
+                  ready: false,
+                };
+                changed = true;
+                return clearedPlot;
+              }
+
+              if (originalCrop) {
                 if (!plot.ready && !plot.pest) {
                   const pestChance = plot.fertilized ? 0.05 : 0.12;
                   if (Math.random() < pestChance) {
-                    if (originalCrop) {
-                      infestedCrops.push(originalCrop.name);
-                    }
+                    infestedCrops.push(originalCrop.name);
                     updatedPlot = { ...plot, pest: true, pestDays: 1 };
                   }
                 }
@@ -957,10 +971,7 @@ const FarmGame = () => {
                   const currentDays = updatedPlot.pestDays ?? 0;
                   const nextDays = currentDays + (plot.pest ? 1 : 0);
                   if (!updatedPlot.ready && nextDays >= 3) {
-                    const damagedCrop = updatedPlot.crop ? CROPS[updatedPlot.crop] : null;
-                    if (damagedCrop) {
-                      destroyedCrops.push(damagedCrop.name);
-                    }
+                    destroyedCrops.push(originalCrop.name);
                     updatedPlot = {
                       ...updatedPlot,
                       crop: null,
@@ -1012,7 +1023,7 @@ const FarmGame = () => {
 
             let processedFarm = nextFarm;
 
-            const vulnerableForStorm = processedFarm.filter(plot => plot.crop && !plot.greenhouse);
+            const vulnerableForStorm = processedFarm.filter(plot => plot.crop && CROPS[plot.crop] && !plot.greenhouse);
             if (vulnerableForStorm.length > 0 && Math.random() < 0.12) {
               const hits = Math.max(1, Math.ceil(vulnerableForStorm.length * 0.25));
               const selectedIds = new Set();
@@ -1043,7 +1054,7 @@ const FarmGame = () => {
               });
             }
 
-            const vulnerableForBlight = processedFarm.filter(plot => plot.crop && !plot.greenhouse && !plot.ready && !plot.pest);
+            const vulnerableForBlight = processedFarm.filter(plot => plot.crop && CROPS[plot.crop] && !plot.greenhouse && !plot.ready && !plot.pest);
             if (vulnerableForBlight.length > 0 && Math.random() < 0.09) {
               const hits = Math.max(1, Math.ceil(vulnerableForBlight.length * 0.3));
               const selectedIds = new Set();
@@ -1135,8 +1146,20 @@ const FarmGame = () => {
     const growTimer = setInterval(() => {
       setFarm(prev => prev.map(plot => {
         if (plot.crop && plot.plantTime && !plot.pest) {
+          const cropData = plot.crop ? CROPS[plot.crop] : null;
+          if (!cropData) {
+            return {
+              ...plot,
+              crop: null,
+              plantTime: null,
+              watered: false,
+              fertilized: false,
+              pest: false,
+              pestDays: 0,
+              ready: false,
+            };
+          }
           const now = Date.now();
-          const cropData = CROPS[plot.crop];
 
           let weatherMultiplier = plot.greenhouse ? 1.2 : (cropData.weatherBonus[weather] || 1);
           const seasonMultiplier = plot.greenhouse ? 1 : (cropData.seasonBonus?.[season] ?? 1);
@@ -1383,9 +1406,11 @@ const FarmGame = () => {
             )}
             <div className="grid grid-cols-5 gap-2 mb-4">
               {farm.map((plot) => {
-                const isReady = Boolean(plot.crop && plot.ready);
+                const cropInfo = plot?.crop ? CROPS[plot.crop] : null;
+                const hasValidCrop = Boolean(cropInfo);
+                const isReady = Boolean(hasValidCrop && plot.ready);
                 const isGreenhouse = Boolean(plot.greenhouse);
-                const isEmpty = !plot.crop;
+                const isEmpty = !hasValidCrop;
                 const highlightForPlacement = pendingGreenhousePlacement && !isGreenhouse;
 
                 let tileStyle = '';
@@ -1395,7 +1420,7 @@ const FarmGame = () => {
                   tileStyle = isEmpty
                     ? 'bg-teal-50 border-teal-400'
                     : 'bg-teal-100 border-teal-400';
-                } else if (plot.crop) {
+                } else if (hasValidCrop) {
                   tileStyle = 'bg-lime-100 border-lime-400';
                 } else {
                   tileStyle = 'bg-gray-100 border-gray-300 hover:bg-green-50';
@@ -1423,11 +1448,11 @@ const FarmGame = () => {
                            }
                          }
 
-                         if (plot.crop && plot.ready) {
+                         if (hasValidCrop && plot.ready) {
                            harvestCrop(plot.id);
-                         } else if (!plot.crop && selectedSeed) {
+                         } else if (!hasValidCrop && selectedSeed) {
                            plantSeed(plot.id);
-                         } else if (plot.crop && !plot.watered) {
+                         } else if (hasValidCrop && !plot.watered) {
                            waterPlot(plot.id);
                          }
                        }}>
@@ -1435,21 +1460,21 @@ const FarmGame = () => {
                       {plot.greenhouse && (
                         <div className="absolute top-0 right-0 text-xs">🏢</div>
                       )}
-                      {plot.pest && (
+                      {hasValidCrop && plot.pest && (
                         <div className="absolute top-0 left-0 text-xs animate-bounce">🐛</div>
                       )}
-                      {plot.fertilized && !plot.ready && (
+                      {hasValidCrop && plot.fertilized && !plot.ready && (
                         <div className="absolute bottom-1 right-1 text-xs">🌿</div>
                       )}
-                      {plot.crop ? (
+                      {hasValidCrop ? (
                         <>
                           <div className={`transform transition-transform duration-500 ${
                             plot.ready ? 'scale-125 animate-bounce' : 'scale-100'
                           }`}>
-                            {CROPS[plot.crop].emoji}
+                            {cropInfo.emoji}
                           </div>
                           <div className="flex absolute bottom-0 left-0 right-0 justify-center">
-                            {plot.watered && <Droplets className="w-3 h-3 text-blue-400" />}
+                            {hasValidCrop && plot.watered && <Droplets className="w-3 h-3 text-blue-400" />}
                           </div>
                         </>
                       ) : (

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -250,6 +250,12 @@ export class GameEngine {
     return `seed_${seedType}`;
   }
 
+  hasValidCrop(plot) {
+    if (!plot) return false;
+    const cropKey = plot.crop;
+    return Boolean(cropKey && CROPS[cropKey]);
+  }
+
   prepareSeed(seedType) {
     const crop = CROPS[seedType];
     if (!crop) {
@@ -482,7 +488,7 @@ export class GameEngine {
         return true;
       }
 
-      if (plot.crop && plot.ready) {
+      if (this.hasValidCrop(plot) && plot.ready) {
         this.notify('作物已成熟，無需再施肥！', { type: 'info' });
         return true;
       }
@@ -498,7 +504,7 @@ export class GameEngine {
     }
 
     if (selectedSupply === 'pesticide') {
-      if (!plot.pest) {
+      if (!this.hasValidCrop(plot) || !plot.pest) {
         this.notify('這塊土地沒有害蟲。', { type: 'info' });
         return true;
       }
@@ -529,7 +535,7 @@ export class GameEngine {
     }
 
     const targetPlot = farmList[targetIndex];
-    if (targetPlot.crop) {
+    if (this.hasValidCrop(targetPlot)) {
       this.notify('這塊土地已經有作物了！', { type: 'info' });
       return;
     }
@@ -637,7 +643,7 @@ export class GameEngine {
   harvestCrop(plotId) {
     const { farm, marketPrices, buildings, season } = this.state;
     const plot = farm.find(p => p.id === plotId);
-    if (!plot || !plot.ready) return;
+    if (!plot || !plot.ready || !this.hasValidCrop(plot)) return;
 
     const crop = plot.crop;
     const basePrice = (marketPrices && marketPrices[crop]) || CROPS[crop].sellPrice;
@@ -687,7 +693,7 @@ export class GameEngine {
     }
 
     this.setters.setFarm(prev => prev.map(plot =>
-      plot.id === plotId && plot.crop && !plot.watered
+      plot.id === plotId && this.hasValidCrop(plot) && !plot.watered
         ? { ...plot, watered: true }
         : plot
     ));

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -204,17 +204,21 @@ export class SaveManager {
       this.setters.setToolLevels(levels);
     }
     const sanitizedFarm = Array.isArray(gameState.farm)
-      ? gameState.farm.map((plot, index) => ({
-          id: plot.id ?? index,
-          crop: plot.crop ?? null,
-          plantTime: plot.plantTime ?? null,
-          watered: plot.crop ? Boolean(plot.watered) : false,
-          fertilized: Boolean(plot.fertilized),
-          greenhouse: Boolean(plot.greenhouse),
-          pest: Boolean(plot.pest),
-          pestDays: plot.pest ? (plot.pestDays ?? 1) : 0,
-          ready: plot.crop ? Boolean(plot.ready) : false,
-        }))
+      ? gameState.farm.map((plot, index) => {
+          const cropKey = typeof plot?.crop === 'string' ? plot.crop.trim() : null;
+          const hasValidCrop = Boolean(cropKey && CROPS[cropKey]);
+          return {
+            id: plot?.id ?? index,
+            crop: hasValidCrop ? cropKey : null,
+            plantTime: hasValidCrop && plot?.plantTime ? plot.plantTime : null,
+            watered: hasValidCrop ? Boolean(plot?.watered) : false,
+            fertilized: hasValidCrop ? Boolean(plot?.fertilized) : false,
+            greenhouse: Boolean(plot?.greenhouse),
+            pest: hasValidCrop ? Boolean(plot?.pest) : false,
+            pestDays: hasValidCrop && plot?.pest ? (plot?.pestDays ?? 1) : 0,
+            ready: hasValidCrop ? Boolean(plot?.ready) : false,
+          };
+        })
       : createDefaultFarm();
 
     const minPlots = Math.max(BASE_FARM_PLOTS, sanitizedFarm.length);


### PR DESCRIPTION
## Summary
- sanitize loaded farm plots and runtime updates so invalid crop keys are cleared out
- gate planting, watering, fertilizer and pesticide actions behind a shared valid-crop check in the game engine
- adjust farm UI and growth ticks to treat missing catalog entries as empty plots for display and interactions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d36b37e51c83299fdccd262016bb58