### PR TITLE
Fix farm plot state sync after farm actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1221,8 +1221,8 @@ const FarmGame = () => {
     gameEngine.buyBuilding(buildingType);
   }, [gameEngine]);
 
-  const buyTool = useCallback((toolType) => {
-    gameEngine.buyTool(toolType);
+  const buyTool = useCallback((toolType, options = {}) => {
+    gameEngine.buyTool(toolType, options);
   }, [gameEngine]);
 
   const slaughterAnimal = useCallback((animalId) => {
@@ -2576,7 +2576,7 @@ const FarmGame = () => {
                             buyTool(key, { upgrade: true });
                           }}
                         >
-                          升級 ${nextUpgradeCost}
+                          {`升級 $${nextUpgradeCost}`}
                         </button>
                       </div>
                     )}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed, TrendingUp, TrendingDown, Clock3, Boxes } from 'lucide-react';
+import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed, TrendingUp, TrendingDown, Clock3, Boxes, Sparkles } from 'lucide-react';
 import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from './game/data/GameCatalog';
 import { GameFormatter } from './game/utils/GameFormatter';
-import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, FARM_EXPANSION_BATCH, ANIMAL_CAPACITY_STEP, BUILDING_UPGRADES } from './game/engine/GameEngine';
+import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, FARM_EXPANSION_BATCH, ANIMAL_CAPACITY_STEP, BUILDING_UPGRADES, ANIMAL_CARE_ACTIONS } from './game/engine/GameEngine';
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
 import { createInitialInventory, INVENTORY_METADATA, INVENTORY_ORDER } from './game/state/InventoryState';
@@ -28,7 +28,24 @@ const ANIMAL_ECOLOGY_CONFIG = {
     happinessWeight: 0.003,
     hungerWeight: 0.0025,
     maxPairsPerType: 3,
+    bondThreshold: 55,
+    bondWeight: 0.0015,
   },
+};
+
+const ANIMAL_INTERACTION_CONFIG = {
+  dailyNeedChance: 0.5,
+  skipHappinessPenalty: 8,
+  escalatedPenalty: 14,
+  neglectBondPenalty: 4,
+  neglectSicknessChance: 0.2,
+  bondDecay: 1,
+  cleanlinessDecay: 7,
+  cleanlinessThreshold: 48,
+  severeCleanlinessThreshold: 28,
+  cleanlinessHappinessPenalty: 6,
+  severeCleanlinessPenalty: 12,
+  cleanlinessSicknessChance: 0.22,
 };
 
 const FarmGame = () => {
@@ -681,6 +698,10 @@ const FarmGame = () => {
             const outbreakVictims = [];
             const overcrowdAlerts = [];
             const newbornAnimals = [];
+            const careReminders = [];
+            const careWarnings = [];
+            const dirtyPens = [];
+            const filthyPens = [];
             const breedingPools = {};
             const capacityLimit = Math.max(animalCapacity || BASE_ANIMAL_CAPACITY, BASE_ANIMAL_CAPACITY);
 
@@ -708,6 +729,60 @@ const FarmGame = () => {
               let sick = Boolean(animal.sick);
               const wasSick = Boolean(animal.sick);
               let sicknessDays = animal.sicknessDays ?? (wasSick ? 1 : 0);
+
+              let bond = Math.max(0, animal.bond ?? 0);
+              bond = Math.max(0, Math.min(100, bond - ANIMAL_INTERACTION_CONFIG.bondDecay));
+              let cleanliness = Math.max(0, animal.cleanliness ?? 80);
+              cleanliness = Math.max(0, Math.min(100, cleanliness - ANIMAL_INTERACTION_CONFIG.cleanlinessDecay));
+
+              let careNeed = animal.careNeed && ANIMAL_CARE_ACTIONS[animal.careNeed] ? animal.careNeed : null;
+              let careDays = Math.max(0, animal.careDays ?? 0);
+              const careKeys = Object.keys(ANIMAL_CARE_ACTIONS);
+              const prioritizeCleaning = cleanliness < ANIMAL_INTERACTION_CONFIG.cleanlinessThreshold && ANIMAL_CARE_ACTIONS.cleanPen;
+
+              if (!careNeed && careKeys.length > 0) {
+                if (prioritizeCleaning) {
+                  careNeed = 'cleanPen';
+                  careDays = 1;
+                } else if (Math.random() < ANIMAL_INTERACTION_CONFIG.dailyNeedChance) {
+                  const randomKey = careKeys[Math.floor(Math.random() * careKeys.length)];
+                  careNeed = randomKey;
+                  careDays = 1;
+                } else {
+                  careDays = 0;
+                }
+
+                if (careNeed) {
+                  const meta = ANIMAL_CARE_ACTIONS[careNeed];
+                  if (meta) {
+                    careReminders.push(`${animal.name} 想要${meta.shortLabel}`);
+                  }
+                }
+              } else if (careNeed) {
+                const meta = ANIMAL_CARE_ACTIONS[careNeed];
+                careDays = Math.max(1, careDays + 1);
+                if (meta) {
+                  careReminders.push(`${animal.name} 需要${meta.shortLabel}`);
+                  if (careDays >= 2) {
+                    const penalty = careDays >= 3
+                      ? ANIMAL_INTERACTION_CONFIG.escalatedPenalty
+                      : ANIMAL_INTERACTION_CONFIG.skipHappinessPenalty;
+                    happiness = Math.max(0, happiness - penalty);
+                    bond = Math.max(0, bond - ANIMAL_INTERACTION_CONFIG.neglectBondPenalty);
+                    if (careDays >= 3) {
+                      careWarnings.push(`${animal.name}（${meta.shortLabel}）`);
+                    }
+                    const sicknessChance = ANIMAL_INTERACTION_CONFIG.neglectSicknessChance * Math.max(1, careDays - 1);
+                    if (!sick && Math.random() < sicknessChance) {
+                      sick = true;
+                      newlySick.push(animal.name);
+                    }
+                  }
+                }
+              } else {
+                careDays = 0;
+              }
+
               let canProduce = happiness > 25 && hunger > ANIMAL_ECOLOGY_CONFIG.hungerWarningThreshold;
 
               if (hunger <= ANIMAL_ECOLOGY_CONFIG.severeHungerThreshold) {
@@ -723,6 +798,20 @@ const FarmGame = () => {
               if (!sick && (hunger <= ANIMAL_ECOLOGY_CONFIG.sicknessTriggerThreshold || happiness <= ANIMAL_ECOLOGY_CONFIG.sicknessTriggerThreshold)) {
                 sick = true;
                 newlySick.push(animal.name);
+              }
+
+              if (cleanliness < ANIMAL_INTERACTION_CONFIG.cleanlinessThreshold) {
+                dirtyPens.push(animal.name);
+                happiness = Math.max(0, happiness - ANIMAL_INTERACTION_CONFIG.cleanlinessHappinessPenalty);
+              }
+              if (cleanliness < ANIMAL_INTERACTION_CONFIG.severeCleanlinessThreshold) {
+                filthyPens.push(animal.name);
+                happiness = Math.max(0, happiness - ANIMAL_INTERACTION_CONFIG.severeCleanlinessPenalty);
+                bond = Math.max(0, bond - 1);
+                if (!sick && Math.random() < ANIMAL_INTERACTION_CONFIG.cleanlinessSicknessChance) {
+                  sick = true;
+                  newlySick.push(animal.name);
+                }
               }
 
               if (sick) {
@@ -765,7 +854,7 @@ const FarmGame = () => {
                 if (!breedingPools[animal.type]) {
                   breedingPools[animal.type] = [];
                 }
-                breedingPools[animal.type].push({ happiness, hunger });
+                breedingPools[animal.type].push({ happiness, hunger, bond });
               }
 
               list.push({
@@ -775,6 +864,10 @@ const FarmGame = () => {
                 sick,
                 sicknessDays,
                 productReady,
+                bond: Math.max(0, Math.min(100, bond)),
+                cleanliness: Math.max(0, Math.min(100, cleanliness)),
+                careNeed: careNeed || null,
+                careDays: careNeed ? careDays : 0,
               });
               return list;
             }, []);
@@ -843,10 +936,12 @@ const FarmGame = () => {
 
               const averageHappiness = candidates.reduce((sum, entry) => sum + entry.happiness, 0) / candidates.length;
               const averageHunger = candidates.reduce((sum, entry) => sum + entry.hunger, 0) / candidates.length;
+              const averageBond = candidates.reduce((sum, entry) => sum + (entry.bond ?? 0), 0) / candidates.length;
               const pairCount = Math.min(Math.floor(candidates.length / 2), ANIMAL_ECOLOGY_CONFIG.breeding.maxPairsPerType);
               const chance = ANIMAL_ECOLOGY_CONFIG.breeding.baseChance
                 + Math.max(0, (averageHappiness - ANIMAL_ECOLOGY_CONFIG.breeding.happyThreshold) * ANIMAL_ECOLOGY_CONFIG.breeding.happinessWeight)
-                + Math.max(0, (averageHunger - ANIMAL_ECOLOGY_CONFIG.breeding.wellFedThreshold) * ANIMAL_ECOLOGY_CONFIG.breeding.hungerWeight);
+                + Math.max(0, (averageHunger - ANIMAL_ECOLOGY_CONFIG.breeding.wellFedThreshold) * ANIMAL_ECOLOGY_CONFIG.breeding.hungerWeight)
+                + Math.max(0, (averageBond - ANIMAL_ECOLOGY_CONFIG.breeding.bondThreshold) * ANIMAL_ECOLOGY_CONFIG.breeding.bondWeight);
 
               for (let attempt = 0; attempt < pairCount && availableSlots > 0; attempt += 1) {
                 if (Math.random() < chance) {
@@ -864,6 +959,11 @@ const FarmGame = () => {
                     sicknessDays: 0,
                     name: babyName,
                     productReady: 0,
+                    bond: 35,
+                    cleanliness: 82,
+                    careNeed: null,
+                    careDays: 0,
+                    lastCareTime: null,
                   });
                   availableSlots -= 1;
                 }
@@ -909,12 +1009,34 @@ const FarmGame = () => {
               addNotification('🐏 動物棲位過於擁擠，建議擴建欄舍或調整飼養量！', { type: 'warning' });
             }
 
+            if (careReminders.length > 0) {
+              const reminders = Array.from(new Set(careReminders));
+              addNotification(`🐾 ${reminders.join('、')}，多陪陪牠們吧！`, { type: 'info' });
+            }
+
+            if (careWarnings.length > 0) {
+              const warnings = Array.from(new Set(careWarnings));
+              addNotification(`⚠️ ${warnings.join('、')} 渴望照護，再忽略可能會生病！`, { type: 'warning' });
+            }
+
+            const urgentDirty = Array.from(new Set(filthyPens));
+            if (urgentDirty.length > 0) {
+              addNotification(`🧼 ${urgentDirty.join('、')} 的欄舍太髒亂了，立即清理以避免疾病！`, { type: 'error' });
+            }
+
+            const regularDirty = Array.from(new Set(dirtyPens.filter(name => !filthyPens.includes(name))));
+            if (regularDirty.length > 0) {
+              addNotification(`🧹 ${regularDirty.join('、')} 的欄舍需要整理，保持清潔讓牠們更安心。`, { type: 'warning' });
+            }
+
             if (newbornAnimals.length > 0) {
               const names = newbornAnimals.map(animal => animal.name).join('、');
               addNotification(`🐣 ${names} 出生了，農場又更熱鬧了！`, { type: 'success' });
             }
 
-            return [...processedAnimals, ...newbornAnimals];
+            const nextAnimals = [...processedAnimals, ...newbornAnimals];
+            stateRef.current.animals = nextAnimals;
+            return nextAnimals;
           });
 
           if (Object.keys(producedGoods).length > 0) {
@@ -1253,6 +1375,10 @@ const FarmGame = () => {
     gameEngine.treatAnimal(animalId);
   }, [gameEngine]);
 
+  const careForAnimal = useCallback((animalId, actionKey) => {
+    gameEngine.careForAnimal(animalId, actionKey);
+  }, [gameEngine]);
+
   const interactNPC = (npc) => {
     setCurrentNPC(npc);
     setShowNPCDialog(true);
@@ -1547,6 +1673,12 @@ const FarmGame = () => {
                     const productInfo = animalData.product ? ANIMAL_PRODUCTS[animalData.product] : null;
                     const readyCount = Math.max(0, Math.floor(animal.productReady || 0));
                     const canCollectProduct = Boolean(productInfo) && readyCount > 0;
+                    const bondValue = Math.max(0, Math.round(animal.bond ?? 0));
+                    const cleanlinessValue = Math.max(0, Math.round(animal.cleanliness ?? 0));
+                    const careNeed = animal.careNeed;
+                    const careMeta = careNeed ? ANIMAL_CARE_ACTIONS[careNeed] : null;
+                    const careDays = Math.max(0, animal.careDays ?? 0);
+                    const careUrgent = careDays >= 3;
                     return (
                       <div key={animal.id}
                            className={`rounded-lg p-3 transition-colors relative border ${
@@ -1589,6 +1721,51 @@ const FarmGame = () => {
                               <div className={`h-1 rounded-full transition-all duration-300 ${isHungry ? 'bg-orange-400' : 'bg-yellow-400'}`}
                                    style={{ width: `${Math.max(0, Math.min(100, hunger))}%` }}></div>
                             </div>
+                            <div className="flex items-center justify-center gap-1 mt-2">
+                              <Sparkles className="w-3 h-3 text-purple-400" />
+                              <span>羈絆 {bondValue}/100</span>
+                            </div>
+                            <div className="bg-gray-200 rounded-full h-1">
+                              <div className="bg-purple-400 h-1 rounded-full transition-all duration-300"
+                                   style={{ width: `${Math.min(100, bondValue)}%` }}></div>
+                            </div>
+                            <div className="flex items-center justify-center gap-1 mt-2">
+                              <Droplets className={`w-3 h-3 ${cleanlinessValue < 30 ? 'text-red-500' : cleanlinessValue < 60 ? 'text-yellow-500' : 'text-teal-500'}`} />
+                              <span>整潔 {cleanlinessValue}%</span>
+                            </div>
+                            <div className="bg-gray-200 rounded-full h-1">
+                              <div className={`h-1 rounded-full transition-all duration-300 ${cleanlinessValue < 30 ? 'bg-red-400' : cleanlinessValue < 60 ? 'bg-yellow-400' : 'bg-teal-400'}`}
+                                   style={{ width: `${Math.min(100, cleanlinessValue)}%` }}></div>
+                            </div>
+                          </div>
+                          <div className={`text-xs mt-2 ${careNeed ? (careUrgent ? 'text-red-600 font-semibold' : 'text-purple-700') : 'text-emerald-600'}`}>
+                            {careNeed
+                              ? `需要：${careMeta?.shortLabel || careMeta?.label || '照護'}${careDays > 1 ? `（等待第 ${careDays} 天）` : ''}`
+                              : '狀態穩定，感謝你的照顧！'}
+                          </div>
+                          <div className="grid grid-cols-3 gap-1 mt-2">
+                            {Object.values(ANIMAL_CARE_ACTIONS).map(action => {
+                              const isRequested = careNeed === action.key;
+                              const insufficientEnergy = energy < action.energyCost;
+                              return (
+                                <button
+                                  key={action.key}
+                                  type="button"
+                                  onClick={() => careForAnimal(animal.id, action.key)}
+                                  disabled={insufficientEnergy}
+                                  title={action.description}
+                                  className={`text-[10px] font-semibold py-1 rounded transition-colors ${insufficientEnergy
+                                    ? 'bg-purple-50 text-purple-300 cursor-not-allowed opacity-60'
+                                    : isRequested
+                                      ? 'bg-purple-400 hover:bg-purple-500 text-purple-900'
+                                      : 'bg-purple-100 hover:bg-purple-200 text-purple-700'
+                                  }`}
+                                >
+                                  {action.shortLabel || action.label}
+                                  <span className="block text-[9px] font-normal">體力 -{action.energyCost}</span>
+                                </button>
+                              );
+                            })}
                           </div>
                           {productInfo ? (
                             <div className="text-xs text-amber-600">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2521,8 +2521,8 @@ const FarmGame = () => {
                 const displayLevel = ownedLevel + 1;
                 const displaySpeed = (tool.speedBoost || 1) + (tool.speedUpgrade || 0) * ownedLevel;
                 const displayEnergy = (tool.energyReduction || 0) + (tool.energyUpgrade || 0) * ownedLevel;
-                const nextUpgradeCost = tool.upgradeCost;
-                const canUpgrade = isOwned && Boolean(nextUpgradeCost);
+                const nextUpgradeCost = gameEngine.getToolUpgradeCost(key, ownedLevel);
+                const canUpgrade = isOwned && nextUpgradeCost !== null;
                 const cardClass = isActive
                   ? 'bg-green-100 border-green-400'
                   : isOwned

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,6 +48,381 @@ const ANIMAL_INTERACTION_CONFIG = {
   cleanlinessSicknessChance: 0.22,
 };
 
+const SEASONAL_FESTIVAL_DEFINITIONS = [
+  {
+    id: 'spring_blossom',
+    season: 'spring',
+    days: [6, 18],
+    duration: 3,
+    name: '春芽花卉節',
+    description: '村莊舉辦花卉節，需要香甜莓果點綴攤位。',
+    requirements: [
+      { type: 'crop', key: 'strawberry', amount: 14 },
+      { type: 'crop', key: 'blueberry', amount: 10 },
+    ],
+    rewards: {
+      money: 420,
+      seeds: [{ crop: 'pumpkin', amount: 3 }],
+    },
+    cooldown: 24,
+  },
+  {
+    id: 'summer_solstice',
+    season: 'summer',
+    days: [9, 21],
+    duration: 3,
+    name: '夏至市集',
+    description: '旅行商人想要用新鮮蔬果打造夏季拼盤。',
+    requirements: [
+      { type: 'crop', key: 'corn', amount: 18 },
+      { type: 'crop', key: 'tomato', amount: 16 },
+    ],
+    rewards: {
+      money: 520,
+      seeds: [{ crop: 'rice', amount: 4 }],
+    },
+    cooldown: 24,
+  },
+  {
+    id: 'autumn_harvest_gala',
+    season: 'autumn',
+    days: [12],
+    duration: 4,
+    name: '秋收盛宴',
+    description: '鎮上的大宴會需要溫暖濃郁的秋季作物。',
+    requirements: [
+      { type: 'crop', key: 'pumpkin', amount: 10 },
+      { type: 'crop', key: 'soybean', amount: 18 },
+    ],
+    rewards: {
+      money: 600,
+      seeds: [{ crop: 'tea', amount: 3 }],
+    },
+    cooldown: 24,
+  },
+  {
+    id: 'winter_lantern_fest',
+    season: 'winter',
+    days: [8, 24],
+    duration: 3,
+    name: '冬燈祭',
+    description: '里長準備暖心晚會，需要主食填滿暖鍋。',
+    requirements: [
+      { type: 'crop', key: 'wheat', amount: 20 },
+      { type: 'crop', key: 'potato', amount: 18 },
+    ],
+    rewards: {
+      money: 480,
+      supplies: [{ key: 'fertilizer', amount: 2 }],
+      seeds: [{ crop: 'strawberry', amount: 4 }],
+    },
+    cooldown: 24,
+  },
+];
+
+const WEATHER_MISSION_DEFINITIONS = [
+  {
+    id: 'storm_repair_drive',
+    weather: 'storm',
+    seasons: ['spring', 'summer', 'autumn'],
+    name: '暴風修復支援',
+    description: '暴風雨後鄰村急需乾草與飼料修繕畜舍。',
+    duration: 2,
+    requirements: [
+      { type: 'crop', key: 'wheat', amount: 18 },
+      { type: 'crop', key: 'corn', amount: 14 },
+    ],
+    rewards: {
+      money: 420,
+      supplies: [{ key: 'pesticide', amount: 2 }],
+      seeds: [{ crop: 'pumpkin', amount: 2 }],
+    },
+    cooldown: 6,
+  },
+  {
+    id: 'rainy_storage_aid',
+    weather: 'rainy',
+    seasons: ['spring', 'summer'],
+    name: '雨季防潮任務',
+    description: '合作社募集黃豆與茶葉調製防潮粉末。',
+    duration: 2,
+    requirements: [
+      { type: 'crop', key: 'soybean', amount: 16 },
+      { type: 'crop', key: 'tea', amount: 10 },
+    ],
+    rewards: {
+      money: 380,
+      supplies: [{ key: 'fertilizer', amount: 2 }],
+    },
+    cooldown: 5,
+  },
+  {
+    id: 'snow_relief_program',
+    weather: 'snow',
+    seasons: ['winter'],
+    name: '雪季保暖補給',
+    description: '鎮公所徵集暖胃食材供應救助站。',
+    duration: 3,
+    requirements: [
+      { type: 'crop', key: 'potato', amount: 16 },
+      { type: 'crop', key: 'rice', amount: 18 },
+    ],
+    rewards: {
+      money: 450,
+      seeds: [{ crop: 'blueberry', amount: 3 }],
+    },
+    cooldown: 7,
+  },
+];
+
+const MARKET_COMMISSION_TEMPLATES = [
+  {
+    id: 'city_bistro_combo',
+    client: '都會餐酒館',
+    seasons: ['spring', 'summer'],
+    description: '客席主廚想用番茄與藍莓打造風味套餐。',
+    duration: 3,
+    requirements: [
+      { type: 'crop', key: 'tomato', amount: 16 },
+      { type: 'crop', key: 'blueberry', amount: 12 },
+    ],
+    rewards: {
+      money: 520,
+      boosts: [{ crop: 'tomato', percent: 0.05 }],
+    },
+  },
+  {
+    id: 'harvest_fair_bundle',
+    client: '農會特採部',
+    seasons: ['autumn'],
+    description: '農會募集秋季作物禮盒，需供應南瓜與黃豆。',
+    duration: 3,
+    requirements: [
+      { type: 'crop', key: 'pumpkin', amount: 12 },
+      { type: 'crop', key: 'soybean', amount: 18 },
+    ],
+    rewards: {
+      money: 640,
+      boosts: [{ crop: 'pumpkin', percent: 0.06 }],
+    },
+  },
+  {
+    id: 'artisan_tea_set',
+    client: '職人工坊',
+    seasons: ['summer', 'autumn'],
+    description: '工坊設計高級茶點組合，需要茶葉與草莓。',
+    duration: 4,
+    requirements: [
+      { type: 'crop', key: 'tea', amount: 12 },
+      { type: 'crop', key: 'strawberry', amount: 14 },
+    ],
+    rewards: {
+      money: 580,
+      boosts: [
+        { crop: 'tea', percent: 0.05 },
+        { crop: 'strawberry', percent: 0.03 },
+      ],
+    },
+  },
+  {
+    id: 'winter_stockpile',
+    client: '北境補給隊',
+    seasons: ['winter'],
+    description: '補給隊準備冬季糧食，徵集馬鈴薯與小麥。',
+    duration: 4,
+    requirements: [
+      { type: 'crop', key: 'potato', amount: 18 },
+      { type: 'crop', key: 'wheat', amount: 22 },
+    ],
+    rewards: {
+      money: 560,
+      boosts: [{ crop: 'wheat', percent: 0.04 }],
+    },
+  },
+];
+
+const MAX_ACTIVE_COMMISSIONS = 3;
+
+const resolveRequirementLabel = (requirement) => {
+  if (!requirement) return '';
+  const { type, key, amount } = requirement;
+  if (type === 'crop' && CROPS[key]) {
+    const crop = CROPS[key];
+    return `${crop.emoji} ${crop.name} x${amount}`;
+  }
+  if (type === 'seed' && CROPS[key]) {
+    const crop = CROPS[key];
+    return `🌱 ${crop.name}種子 x${amount}`;
+  }
+  if (type === 'product' && ANIMAL_PRODUCTS[key]) {
+    const product = ANIMAL_PRODUCTS[key];
+    return `${product.emoji} ${product.name} x${amount}`;
+  }
+  if (type === 'supply' && FARM_SUPPLIES[key]) {
+    const supply = FARM_SUPPLIES[key];
+    return `${supply.emoji || '📦'} ${supply.name} x${amount}`;
+  }
+  return `${key} x${amount}`;
+};
+
+const getRequirementInventoryKey = (requirement) => {
+  if (!requirement) return null;
+  const { type, key } = requirement;
+  switch (type) {
+    case 'crop':
+    case 'product':
+      return key;
+    case 'seed':
+      return `seed_${key}`;
+    default:
+      return null;
+  }
+};
+
+const getRequirementCurrentAmount = (requirement, inventory, farmSupplies) => {
+  if (!requirement) return 0;
+  const { type, key } = requirement;
+  if (type === 'supply') {
+    return farmSupplies?.[key] || 0;
+  }
+  const inventoryKey = getRequirementInventoryKey(requirement);
+  if (!inventoryKey) {
+    return 0;
+  }
+  return inventory?.[inventoryKey] || 0;
+};
+
+const canFulfillRequirements = (requirements, inventory, farmSupplies) => {
+  if (!Array.isArray(requirements) || requirements.length === 0) {
+    return true;
+  }
+  return requirements.every(req => getRequirementCurrentAmount(req, inventory, farmSupplies) >= (req.amount || 0));
+};
+
+const applyRequirementSpending = (requirements, setInventory, setFarmSupplies) => {
+  if (!Array.isArray(requirements) || requirements.length === 0) {
+    return;
+  }
+
+  const supplyRequirements = requirements.filter(req => req.type === 'supply');
+  const inventoryRequirements = requirements.filter(req => req.type !== 'supply');
+
+  if (inventoryRequirements.length > 0) {
+    setInventory(prev => {
+      const next = { ...(prev || {}) };
+      inventoryRequirements.forEach(req => {
+        const key = getRequirementInventoryKey(req);
+        if (!key) return;
+        const current = next[key] || 0;
+        next[key] = Math.max(0, current - (req.amount || 0));
+      });
+      return next;
+    });
+  }
+
+  if (supplyRequirements.length > 0) {
+    setFarmSupplies(prev => {
+      const base = prev || {};
+      const next = { ...base };
+      supplyRequirements.forEach(req => {
+        const current = next[req.key] || 0;
+        next[req.key] = Math.max(0, current - (req.amount || 0));
+      });
+      return next;
+    });
+  }
+};
+
+const applyRewardGrant = ({ rewards }, { setMoney, setInventory, setFarmSupplies, setMarketBoosts }) => {
+  if (!rewards) {
+    return;
+  }
+
+  if (rewards.money) {
+    setMoney(prev => prev + rewards.money);
+  }
+
+  if (Array.isArray(rewards.seeds) && rewards.seeds.length > 0) {
+    setInventory(prev => {
+      const next = { ...(prev || {}) };
+      rewards.seeds.forEach(seed => {
+        if (!seed?.crop || !seed.amount) return;
+        const key = `seed_${seed.crop}`;
+        next[key] = (next[key] || 0) + seed.amount;
+      });
+      return next;
+    });
+  }
+
+  if (Array.isArray(rewards.supplies) && rewards.supplies.length > 0) {
+    setFarmSupplies(prev => {
+      const base = prev || {};
+      const next = { ...base };
+      rewards.supplies.forEach(supply => {
+        if (!supply?.key || !supply.amount) return;
+        next[supply.key] = (next[supply.key] || 0) + supply.amount;
+      });
+      return next;
+    });
+  }
+
+  if (Array.isArray(rewards.boosts) && rewards.boosts.length > 0) {
+    setMarketBoosts(prev => {
+      const base = prev || {};
+      const next = { ...base };
+      rewards.boosts.forEach(boost => {
+        if (!boost?.crop || !boost.percent) return;
+        next[boost.crop] = (next[boost.crop] || 0) + boost.percent;
+      });
+      return next;
+    });
+  }
+};
+
+const describeRewards = (rewards) => {
+  if (!rewards) {
+    return '';
+  }
+
+  const parts = [];
+  if (rewards.money) {
+    parts.push(`金額 $${rewards.money}`);
+  }
+  if (Array.isArray(rewards.seeds) && rewards.seeds.length > 0) {
+    const seedText = rewards.seeds
+      .map(seed => {
+        const crop = CROPS[seed.crop];
+        const label = crop ? `${crop.emoji} ${crop.name}種子` : `${seed.crop}種子`;
+        return `${label} x${seed.amount}`;
+      })
+      .join('、');
+    parts.push(seedText);
+  }
+  if (Array.isArray(rewards.supplies) && rewards.supplies.length > 0) {
+    const supplyText = rewards.supplies
+      .map(supply => {
+        const meta = FARM_SUPPLIES[supply.key];
+        const label = meta ? `${meta.emoji || '📦'} ${meta.name}` : supply.key;
+        return `${label} x${supply.amount}`;
+      })
+      .join('、');
+    parts.push(supplyText);
+  }
+  if (Array.isArray(rewards.boosts) && rewards.boosts.length > 0) {
+    const boostText = rewards.boosts
+      .map(boost => {
+        const crop = CROPS[boost.crop];
+        const percent = Math.round((boost.percent || 0) * 100);
+        const label = crop ? `${crop.emoji} ${crop.name}` : boost.crop;
+        return `${label} 價格永久 +${percent}%`;
+      })
+      .join('、');
+    parts.push(boostText);
+  }
+
+  return parts.join('、');
+};
+
 const FarmGame = () => {
   // 基本狀態
   const [money, setMoney] = useState(500);
@@ -138,6 +513,170 @@ const FarmGame = () => {
     [questManager, dynamicQuests],
   );
 
+  const handleDailyEvents = useCallback((newDay, effectiveSeason, currentWeather) => {
+    const dayInSeason = ((newDay - 1) % 30) + 1;
+
+    const existingSeasonal = Array.isArray(stateRef.current.seasonalEvents)
+      ? stateRef.current.seasonalEvents
+      : [];
+    const seasonalHistoryState = stateRef.current.seasonalEventHistory || {};
+    const activeSeasonal = [];
+    existingSeasonal.forEach(event => {
+      if ((event.expiresOn ?? 0) < newDay) {
+        if (!event.completed) {
+          addNotification(`⏳ ${event.name} 已結束，未來再參與吧！`, { type: 'warning' });
+        }
+      } else {
+        activeSeasonal.push(event);
+      }
+    });
+
+    let seasonalList = [...activeSeasonal];
+    const seasonalHistoryUpdates = {};
+
+    SEASONAL_FESTIVAL_DEFINITIONS.forEach(definition => {
+      if (definition.season !== effectiveSeason) {
+        return;
+      }
+      const scheduledDays = Array.isArray(definition.days) ? definition.days : [definition.days];
+      if (!scheduledDays.includes(dayInSeason)) {
+        return;
+      }
+      const cooldown = definition.cooldown ?? 0;
+      const lastTrigger = seasonalHistoryState[definition.id] || 0;
+      if (lastTrigger && newDay - lastTrigger < cooldown) {
+        return;
+      }
+      if (seasonalList.some(event => event.templateId === definition.id)) {
+        return;
+      }
+      const instance = {
+        ...definition,
+        templateId: definition.id,
+        instanceId: `${definition.id}_${newDay}`,
+        startedOn: newDay,
+        expiresOn: newDay + Math.max(1, (definition.duration ?? 2)) - 1,
+      };
+      seasonalList.push(instance);
+      seasonalHistoryUpdates[definition.id] = newDay;
+      const requirementLabel = (definition.requirements || []).map(resolveRequirementLabel).join('、');
+      addNotification(`🎊 ${definition.name} 開跑！${definition.description}${requirementLabel ? `（需求：${requirementLabel}）` : ''}`,
+        { type: 'info' });
+    });
+
+    setSeasonalEvents(seasonalList);
+    if (Object.keys(seasonalHistoryUpdates).length > 0) {
+      setSeasonalEventHistory(prev => ({ ...(prev || {}), ...seasonalHistoryUpdates }));
+    }
+
+    const existingWeatherMissions = Array.isArray(stateRef.current.weatherMissions)
+      ? stateRef.current.weatherMissions
+      : [];
+    const weatherHistoryState = stateRef.current.weatherMissionHistory || {};
+    const activeWeather = [];
+    existingWeatherMissions.forEach(mission => {
+      if ((mission.expiresOn ?? 0) < newDay) {
+        addNotification(`⏳ ${mission.name} 已截止。`, { type: 'warning' });
+      } else {
+        activeWeather.push(mission);
+      }
+    });
+
+    let weatherList = [...activeWeather];
+    const weatherHistoryUpdates = {};
+
+    WEATHER_MISSION_DEFINITIONS.forEach(definition => {
+      if (definition.weather !== currentWeather) {
+        return;
+      }
+      if (Array.isArray(definition.seasons) && !definition.seasons.includes(effectiveSeason)) {
+        return;
+      }
+      const cooldown = definition.cooldown ?? 0;
+      const lastTrigger = weatherHistoryState[definition.id] || 0;
+      if (lastTrigger && newDay - lastTrigger < cooldown) {
+        return;
+      }
+      if (weatherList.some(mission => mission.templateId === definition.id)) {
+        return;
+      }
+      const instance = {
+        ...definition,
+        templateId: definition.id,
+        instanceId: `${definition.id}_${newDay}`,
+        startedOn: newDay,
+        expiresOn: newDay + Math.max(1, (definition.duration ?? 2)) - 1,
+      };
+      weatherList.push(instance);
+      weatherHistoryUpdates[definition.id] = newDay;
+      const requirementLabel = (definition.requirements || []).map(resolveRequirementLabel).join('、');
+      addNotification(`🌦️ ${definition.name} 啟動：${definition.description}${requirementLabel ? `（需求：${requirementLabel}）` : ''}`,
+        { type: 'info' });
+    });
+
+    setWeatherMissions(weatherList);
+    if (Object.keys(weatherHistoryUpdates).length > 0) {
+      setWeatherMissionHistory(prev => ({ ...(prev || {}), ...weatherHistoryUpdates }));
+    }
+
+    const existingCommissions = Array.isArray(stateRef.current.marketCommissions)
+      ? stateRef.current.marketCommissions
+      : [];
+    const commissionHistoryState = stateRef.current.commissionHistory || {};
+    const activeCommissions = [];
+    existingCommissions.forEach(order => {
+      if ((order.expiresOn ?? 0) < newDay) {
+        addNotification(`📦 ${order.client} 的委託已過期。`, { type: 'warning' });
+      } else {
+        activeCommissions.push(order);
+      }
+    });
+
+    let commissionList = [...activeCommissions];
+    const commissionHistoryUpdates = {};
+
+    if (commissionList.length < MAX_ACTIVE_COMMISSIONS) {
+      const eligible = MARKET_COMMISSION_TEMPLATES.filter(template => {
+        if (Array.isArray(template.seasons) && !template.seasons.includes(effectiveSeason)) {
+          return false;
+        }
+        const lastTrigger = commissionHistoryState[template.id] || 0;
+        if (lastTrigger && newDay - lastTrigger < 5) {
+          return false;
+        }
+        if (commissionList.some(order => order.templateId === template.id)) {
+          return false;
+        }
+        return true;
+      });
+
+      const shuffled = [...eligible].sort(() => Math.random() - 0.5);
+      while (commissionList.length < MAX_ACTIVE_COMMISSIONS && shuffled.length > 0) {
+        const template = shuffled.shift();
+        if (!template) {
+          break;
+        }
+        const instance = {
+          ...template,
+          templateId: template.id,
+          instanceId: `${template.id}_${newDay}_${commissionList.length}`,
+          startedOn: newDay,
+          expiresOn: newDay + Math.max(1, (template.duration ?? 3)) - 1,
+        };
+        commissionList.push(instance);
+        commissionHistoryUpdates[template.id] = newDay;
+        const requirementLabel = (template.requirements || []).map(resolveRequirementLabel).join('、');
+        addNotification(`📝 ${template.client} 發布委託：${template.description}${requirementLabel ? `（需求：${requirementLabel}）` : ''}`,
+          { type: 'info' });
+      }
+    }
+
+    setMarketCommissions(commissionList);
+    if (Object.keys(commissionHistoryUpdates).length > 0) {
+      setCommissionHistory(prev => ({ ...(prev || {}), ...commissionHistoryUpdates }));
+    }
+  }, [addNotification, setSeasonalEvents, setSeasonalEventHistory, setWeatherMissions, setWeatherMissionHistory, setMarketCommissions, setCommissionHistory, stateRef]);
+
   useEffect(() => {
     questManager.refreshDaily(day);
   }, [questManager, day]);
@@ -182,7 +721,14 @@ const FarmGame = () => {
   const [marketUpdateTime, setMarketUpdateTime] = useState(null);
   const [dailyStats, setDailyStats] = useState([]);
   const [automation, setAutomation] = useState({ autoWater: false, autoHarvest: false });
-  
+  const [seasonalEvents, setSeasonalEvents] = useState([]);
+  const [seasonalEventHistory, setSeasonalEventHistory] = useState({});
+  const [weatherMissions, setWeatherMissions] = useState([]);
+  const [weatherMissionHistory, setWeatherMissionHistory] = useState({});
+  const [marketCommissions, setMarketCommissions] = useState([]);
+  const [commissionHistory, setCommissionHistory] = useState({});
+  const [marketBoosts, setMarketBoosts] = useState({});
+
   // 存檔狀態
   const [saveSlots, setSaveSlots] = useState({
     slot1: null,
@@ -221,6 +767,13 @@ const FarmGame = () => {
     previousMarketPrices,
     marketUpdateTime,
     saveSlots,
+    seasonalEvents,
+    seasonalEventHistory,
+    weatherMissions,
+    weatherMissionHistory,
+    marketCommissions,
+    commissionHistory,
+    marketBoosts,
     selectedSeed,
     selectedSupply,
     loadData,
@@ -260,6 +813,13 @@ const FarmGame = () => {
       setPreviousMarketPrices,
       setMarketUpdateTime,
       setSaveSlots,
+      setSeasonalEvents,
+      setSeasonalEventHistory,
+      setWeatherMissions,
+      setWeatherMissionHistory,
+      setMarketCommissions,
+      setCommissionHistory,
+      setMarketBoosts,
       setShowSaveMenu,
       setShowLoadMenu,
       setLoadData,
@@ -612,10 +1172,12 @@ const FarmGame = () => {
     const updatePrices = () => {
       const previousSnapshot = stateRef.current.marketPrices || {};
       const newPrices = {};
+      const boosts = stateRef.current.marketBoosts || {};
       Object.keys(CROPS).forEach(crop => {
         const basePrice = CROPS[crop].sellPrice;
         const fluctuation = 0.8 + Math.random() * 0.4;
-        newPrices[crop] = Math.floor(basePrice * fluctuation);
+        const boostMultiplier = 1 + (boosts[crop] || 0);
+        newPrices[crop] = Math.floor(basePrice * fluctuation * boostMultiplier);
       });
       setPreviousMarketPrices(previousSnapshot);
       setMarketPrices(newPrices);
@@ -625,7 +1187,7 @@ const FarmGame = () => {
     updatePrices();
     const timer = setInterval(updatePrices, 120000);
     return () => clearInterval(timer);
-  }, [stateRef]);
+  }, [stateRef, marketBoosts]);
 
   // 成就系統
   useEffect(() => {
@@ -669,17 +1231,23 @@ const FarmGame = () => {
       setTime(prev => {
         const newTime = prev + 1;
         if (newTime >= 24) {
-          setDay(prevDay => {
-            const newDay = prevDay + 1;
-            if (newDay % 30 === 0) {
-              const currentSeasonIndex = SEASONS.indexOf(season);
-              const nextSeason = SEASONS[(currentSeasonIndex + 1) % SEASONS.length];
-              setSeason(nextSeason);
-              addNotification(`🌸 季節變為 ${GameFormatter.seasonName(nextSeason)}！`, { type: 'info' });
-            }
-            return newDay;
-          });
-          
+          const currentDay = stateRef.current.day || day;
+          const currentSeason = stateRef.current.season || season;
+          const currentWeather = stateRef.current.weather || weather;
+          const upcomingDay = currentDay + 1;
+          const willChangeSeason = upcomingDay % 30 === 0;
+          const currentSeasonIndex = SEASONS.indexOf(currentSeason);
+          const nextSeasonValue = willChangeSeason
+            ? SEASONS[(currentSeasonIndex + 1) % SEASONS.length]
+            : currentSeason;
+
+          setDay(upcomingDay);
+          if (willChangeSeason) {
+            setSeason(nextSeasonValue);
+            addNotification(`🌸 季節變為 ${GameFormatter.seasonName(nextSeasonValue)}！`, { type: 'info' });
+          }
+
+          handleDailyEvents(upcomingDay, nextSeasonValue, currentWeather);
           setEnergy(100);
 
           // 動物每日狀態與收入結算
@@ -1235,7 +1803,7 @@ const FarmGame = () => {
     }, 15000);
 
     return () => clearInterval(timer);
-  }, [season, buildings, animals, addNotification, gameEngine, animalCapacity]);
+  }, [season, buildings, animals, addNotification, gameEngine, animalCapacity, handleDailyEvents, day, weather]);
 
   // 天氣系統
   useEffect(() => {
@@ -1378,6 +1946,77 @@ const FarmGame = () => {
   const careForAnimal = useCallback((animalId, actionKey) => {
     gameEngine.careForAnimal(animalId, actionKey);
   }, [gameEngine]);
+
+  const completeSeasonalEvent = useCallback((instanceId) => {
+    const currentEvents = Array.isArray(stateRef.current.seasonalEvents)
+      ? stateRef.current.seasonalEvents
+      : [];
+    const target = currentEvents.find(event => event.instanceId === instanceId);
+    if (!target) {
+      return;
+    }
+
+    const currentInventory = stateRef.current.inventory || inventory;
+    const currentSupplies = stateRef.current.farmSupplies || farmSupplies;
+    if (!canFulfillRequirements(target.requirements, currentInventory, currentSupplies)) {
+      addNotification('庫存不足，暫時無法支援這項活動。', { type: 'warning' });
+      return;
+    }
+
+    applyRequirementSpending(target.requirements, setInventory, setFarmSupplies);
+    applyRewardGrant(target, { setMoney, setInventory, setFarmSupplies, setMarketBoosts });
+    setSeasonalEvents(prev => prev.filter(event => event.instanceId !== instanceId));
+    const rewardSummary = describeRewards(target.rewards);
+    addNotification(`🎉 已支援 ${target.name}！${rewardSummary ? `獲得 ${rewardSummary}` : '村民們十分感謝你的協助！'}`,
+      { type: 'success' });
+  }, [stateRef, inventory, farmSupplies, addNotification, setInventory, setFarmSupplies, setSeasonalEvents, setMoney, setMarketBoosts]);
+
+  const completeWeatherMission = useCallback((instanceId) => {
+    const currentMissions = Array.isArray(stateRef.current.weatherMissions)
+      ? stateRef.current.weatherMissions
+      : [];
+    const target = currentMissions.find(mission => mission.instanceId === instanceId);
+    if (!target) {
+      return;
+    }
+
+    const currentInventory = stateRef.current.inventory || inventory;
+    const currentSupplies = stateRef.current.farmSupplies || farmSupplies;
+    if (!canFulfillRequirements(target.requirements, currentInventory, currentSupplies)) {
+      addNotification('準備的物資不足，無法完成這項天氣任務。', { type: 'warning' });
+      return;
+    }
+
+    applyRequirementSpending(target.requirements, setInventory, setFarmSupplies);
+    applyRewardGrant(target, { setMoney, setInventory, setFarmSupplies, setMarketBoosts });
+    setWeatherMissions(prev => prev.filter(mission => mission.instanceId !== instanceId));
+    const rewardSummary = describeRewards(target.rewards);
+    addNotification(`✅ 已完成「${target.name}」，${rewardSummary ? `獎勵：${rewardSummary}` : '村務局派人表達謝意！'}`,
+      { type: 'success' });
+  }, [stateRef, inventory, farmSupplies, addNotification, setInventory, setFarmSupplies, setWeatherMissions, setMoney, setMarketBoosts]);
+
+  const fulfillMarketCommission = useCallback((instanceId) => {
+    const currentOrders = Array.isArray(stateRef.current.marketCommissions)
+      ? stateRef.current.marketCommissions
+      : [];
+    const target = currentOrders.find(order => order.instanceId === instanceId);
+    if (!target) {
+      return;
+    }
+
+    const currentInventory = stateRef.current.inventory || inventory;
+    const currentSupplies = stateRef.current.farmSupplies || farmSupplies;
+    if (!canFulfillRequirements(target.requirements, currentInventory, currentSupplies)) {
+      addNotification('倉庫存量不足，無法交付這筆委託。', { type: 'warning' });
+      return;
+    }
+
+    applyRequirementSpending(target.requirements, setInventory, setFarmSupplies);
+    applyRewardGrant(target, { setMoney, setInventory, setFarmSupplies, setMarketBoosts });
+    setMarketCommissions(prev => prev.filter(order => order.instanceId !== instanceId));
+    const rewardSummary = describeRewards(target.rewards);
+    addNotification(`📦 已完成 ${target.client} 的委託！${rewardSummary ? `獲得 ${rewardSummary}` : ''}`, { type: 'success' });
+  }, [stateRef, inventory, farmSupplies, addNotification, setInventory, setFarmSupplies, setMarketCommissions, setMoney, setMarketBoosts]);
 
   const interactNPC = (npc) => {
     setCurrentNPC(npc);
@@ -1986,6 +2625,142 @@ const FarmGame = () => {
               </div>
             </div>
 
+            {/* 季節活動中心 */}
+            <div className="bg-white bg-opacity-90 rounded-lg p-4 shadow-lg">
+              <h3 className="text-lg font-bold flex items-center gap-2 mb-3">
+                <Sparkles className="w-4 h-4 text-amber-500" />
+                季節活動中心
+              </h3>
+              {seasonalEvents.length === 0 && weatherMissions.length === 0 ? (
+                <p className="text-sm text-gray-500">
+                  目前沒有特別活動，專心耕作並等待下一波慶典與任務吧！
+                </p>
+              ) : (
+                <div className="space-y-4">
+                  {seasonalEvents.length > 0 && (
+                    <div>
+                      <h4 className="text-sm font-semibold text-amber-600 mb-2">季節慶典</h4>
+                      <div className="space-y-2">
+                        {seasonalEvents.map(event => {
+                          const requirements = event.requirements || [];
+                          const canComplete = canFulfillRequirements(requirements, inventory, farmSupplies);
+                          const daysLeft = Math.max(0, (event.expiresOn ?? day) - day + 1);
+                          const rewardSummary = describeRewards(event.rewards);
+                          return (
+                            <div key={event.instanceId}
+                                 className="border border-amber-200 bg-amber-50/70 rounded-lg p-3">
+                              <div className="flex items-start justify-between gap-2">
+                                <div>
+                                  <p className="text-sm font-semibold text-amber-700 leading-snug">{event.name}</p>
+                                  <p className="text-xs text-gray-600 mt-1">{event.description}</p>
+                                </div>
+                                <span className={`text-[11px] px-2 py-1 rounded-full ${daysLeft <= 1 ? 'bg-red-100 text-red-600' : 'bg-amber-100 text-amber-700'}`}>
+                                  剩餘 {daysLeft} 天
+                                </span>
+                              </div>
+                              {requirements.length > 0 && (
+                                <ul className="mt-2 space-y-1">
+                                  {requirements.map((requirement, index) => {
+                                    const owned = getRequirementCurrentAmount(requirement, inventory, farmSupplies);
+                                    const goal = requirement.amount || 0;
+                                    const label = resolveRequirementLabel(requirement);
+                                    const met = owned >= goal;
+                                    return (
+                                      <li key={`${event.instanceId}-req-${index}`}
+                                          className="flex items-center justify-between text-xs text-gray-600">
+                                        <span>{label}</span>
+                                        <span className={met ? 'text-green-600 font-semibold' : 'text-gray-500'}>
+                                          {owned}/{goal}
+                                        </span>
+                                      </li>
+                                    );
+                                  })}
+                                </ul>
+                              )}
+                              {rewardSummary && (
+                                <p className="mt-2 text-xs text-amber-700">獎勵：{rewardSummary}</p>
+                              )}
+                              <div className="mt-3 flex justify-end">
+                                <button
+                                  onClick={() => completeSeasonalEvent(event.instanceId)}
+                                  disabled={!canComplete}
+                                  className={`text-xs font-semibold px-3 py-1 rounded transition-colors ${canComplete
+                                    ? 'bg-amber-500 text-white hover:bg-amber-600'
+                                    : 'bg-gray-200 text-gray-400 cursor-not-allowed'}`}
+                                >
+                                  提供支援
+                                </button>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                  {weatherMissions.length > 0 && (
+                    <div>
+                      <h4 className="text-sm font-semibold text-sky-600 mb-2">天氣任務</h4>
+                      <div className="space-y-2">
+                        {weatherMissions.map(mission => {
+                          const requirements = mission.requirements || [];
+                          const canComplete = canFulfillRequirements(requirements, inventory, farmSupplies);
+                          const daysLeft = Math.max(0, (mission.expiresOn ?? day) - day + 1);
+                          const rewardSummary = describeRewards(mission.rewards);
+                          return (
+                            <div key={mission.instanceId}
+                                 className="border border-sky-200 bg-sky-50/70 rounded-lg p-3">
+                              <div className="flex items-start justify-between gap-2">
+                                <div>
+                                  <p className="text-sm font-semibold text-sky-700 leading-snug">{mission.name}</p>
+                                  <p className="text-xs text-gray-600 mt-1">{mission.description}</p>
+                                </div>
+                                <span className={`text-[11px] px-2 py-1 rounded-full ${daysLeft <= 1 ? 'bg-red-100 text-red-600' : 'bg-sky-100 text-sky-700'}`}>
+                                  剩餘 {daysLeft} 天
+                                </span>
+                              </div>
+                              {requirements.length > 0 && (
+                                <ul className="mt-2 space-y-1">
+                                  {requirements.map((requirement, index) => {
+                                    const owned = getRequirementCurrentAmount(requirement, inventory, farmSupplies);
+                                    const goal = requirement.amount || 0;
+                                    const label = resolveRequirementLabel(requirement);
+                                    const met = owned >= goal;
+                                    return (
+                                      <li key={`${mission.instanceId}-req-${index}`}
+                                          className="flex items-center justify-between text-xs text-gray-600">
+                                        <span>{label}</span>
+                                        <span className={met ? 'text-green-600 font-semibold' : 'text-gray-500'}>
+                                          {owned}/{goal}
+                                        </span>
+                                      </li>
+                                    );
+                                  })}
+                                </ul>
+                              )}
+                              {rewardSummary && (
+                                <p className="mt-2 text-xs text-sky-700">獎勵：{rewardSummary}</p>
+                              )}
+                              <div className="mt-3 flex justify-end">
+                                <button
+                                  onClick={() => completeWeatherMission(mission.instanceId)}
+                                  disabled={!canComplete}
+                                  className={`text-xs font-semibold px-3 py-1 rounded transition-colors ${canComplete
+                                    ? 'bg-sky-500 text-white hover:bg-sky-600'
+                                    : 'bg-gray-200 text-gray-400 cursor-not-allowed'}`}
+                                >
+                                  完成任務
+                                </button>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
             {/* 市場價格 */}
             <div className="bg-white bg-opacity-90 rounded-lg p-4 shadow-lg">
               <div className="flex flex-wrap items-start justify-between gap-2 mb-3">
@@ -2027,6 +2802,73 @@ const FarmGame = () => {
                     style={{ width: `${Math.min(100, Math.max(6, marketInsights.averageIndex * 100))}%` }}
                   ></div>
                 </div>
+              </div>
+              <div className="mb-3 border border-emerald-200 bg-emerald-50/70 rounded-lg p-3">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-1 text-xs font-semibold text-emerald-700 uppercase tracking-wide">
+                    <Boxes className="w-3 h-3" />
+                    市場委託
+                  </div>
+                  <span className="text-[11px] text-emerald-700">活躍 {marketCommissions.length}/{MAX_ACTIVE_COMMISSIONS}</span>
+                </div>
+                {marketCommissions.length > 0 ? (
+                  <div className="space-y-2">
+                    {marketCommissions.map(order => {
+                      const requirements = order.requirements || [];
+                      const canComplete = canFulfillRequirements(requirements, inventory, farmSupplies);
+                      const daysLeft = Math.max(0, (order.expiresOn ?? day) - day + 1);
+                      const rewardSummary = describeRewards(order.rewards);
+                      return (
+                        <div key={order.instanceId} className="border border-emerald-200 bg-white/80 rounded-lg p-3">
+                          <div className="flex items-start justify-between gap-2">
+                            <div>
+                              <p className="text-sm font-semibold text-emerald-700">{order.client}</p>
+                              <p className="text-xs text-gray-600 mt-1 leading-snug">{order.description}</p>
+                            </div>
+                            <span className={`text-[11px] px-2 py-1 rounded-full ${daysLeft <= 1 ? 'bg-red-100 text-red-600' : 'bg-emerald-100 text-emerald-700'}`}>
+                              剩餘 {daysLeft} 天
+                            </span>
+                          </div>
+                          {requirements.length > 0 && (
+                            <ul className="mt-2 space-y-1">
+                              {requirements.map((requirement, index) => {
+                                const owned = getRequirementCurrentAmount(requirement, inventory, farmSupplies);
+                                const goal = requirement.amount || 0;
+                                const label = resolveRequirementLabel(requirement);
+                                const met = owned >= goal;
+                                return (
+                                  <li key={`${order.instanceId}-req-${index}`}
+                                      className="flex items-center justify-between text-xs text-gray-600">
+                                    <span>{label}</span>
+                                    <span className={met ? 'text-green-600 font-semibold' : 'text-gray-500'}>
+                                      {owned}/{goal}
+                                    </span>
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          )}
+                          {rewardSummary && (
+                            <p className="mt-2 text-xs text-emerald-700">獎勵：{rewardSummary}</p>
+                          )}
+                          <div className="mt-3 flex justify-end">
+                            <button
+                              onClick={() => fulfillMarketCommission(order.instanceId)}
+                              disabled={!canComplete}
+                              className={`text-xs font-semibold px-3 py-1 rounded transition-colors ${canComplete
+                                ? 'bg-emerald-500 text-white hover:bg-emerald-600'
+                                : 'bg-gray-200 text-gray-400 cursor-not-allowed'}`}
+                            >
+                              交付委託
+                            </button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-xs text-gray-500">今日暫無委託訂單，靜候新的需求。</p>
+                )}
               </div>
               {marketView === 'summary' ? (
                 <>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2364,7 +2364,7 @@ const FarmGame = () => {
                       倉庫種子: {inventory[`seed_${selectedSeed}`] || 0} 包
                     </div>
                     <div className="text-xs text-gray-500">
-                      無庫存時植入需花費 ${marketPrices[selectedSeed] || CROPS[selectedSeed].price}
+                      無庫存時植入需花費 ${CROPS[selectedSeed].price}
                     </div>
                   </div>
                 </div>
@@ -2476,7 +2476,8 @@ const FarmGame = () => {
             <h2 className="text-xl font-bold mb-4">種子商店</h2>
             <div className="grid grid-cols-3 gap-4">
               {Object.entries(CROPS).map(([key, crop]) => {
-                const price = marketPrices[key] || crop.price;
+                const seedCost = crop.price;
+                const marketValue = marketPrices[key] || crop.sellPrice;
                 const seedKey = `seed_${key}`;
                 const storedSeeds = inventory[seedKey] || 0;
                 const seasonEntries = Object.entries(crop.seasonBonus || {});
@@ -2493,9 +2494,10 @@ const FarmGame = () => {
                     <div className="text-center space-y-1">
                       <div className="text-3xl">{crop.emoji}</div>
                       <div className="font-semibold">{crop.name}</div>
-                      <div className="text-green-600 font-bold">${price}</div>
+                      <div className="text-green-600 font-bold">種子 ${seedCost}</div>
                       <div className="text-xs text-gray-500">成長: {crop.growTime}分鐘</div>
                       <div className="text-xs text-blue-600">基礎售價: ${crop.sellPrice}</div>
+                      <div className="text-xs text-emerald-600">今日市價: ${marketValue}</div>
                       <div className="text-xs text-amber-600">種子庫存: {storedSeeds} 包</div>
                       {favorableSeasons.length > 0 && (
                         <div className="text-[11px] text-emerald-600">適合季節：{favorableSeasons.join('、')}</div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1071,7 +1071,9 @@ const FarmGame = () => {
               });
             }
 
-            return changed ? processedFarm : prevFarm;
+            const resultFarm = changed ? processedFarm : prevFarm;
+            stateRef.current.farm = resultFarm;
+            return resultFarm;
           });
 
           if (infestedCrops.length > 0) {
@@ -1133,26 +1135,30 @@ const FarmGame = () => {
   // 作物成長系統
   useEffect(() => {
     const growTimer = setInterval(() => {
-      setFarm(prev => prev.map(plot => {
-        if (plot.crop && plot.plantTime && !plot.pest) {
-          const now = Date.now();
-          const cropData = CROPS[plot.crop];
+      setFarm(prev => {
+        const updatedFarm = prev.map(plot => {
+          if (plot.crop && plot.plantTime && !plot.pest) {
+            const now = Date.now();
+            const cropData = CROPS[plot.crop];
 
-          let weatherMultiplier = plot.greenhouse ? 1.2 : (cropData.weatherBonus[weather] || 1);
-          const seasonMultiplier = plot.greenhouse ? 1 : (cropData.seasonBonus?.[season] ?? 1);
-          const toolMultiplier = effectiveToolStats.speedBoost;
-          const fertilizerBoost = plot.fertilized ? 1.25 : 1;
+            let weatherMultiplier = plot.greenhouse ? 1.2 : (cropData.weatherBonus[weather] || 1);
+            const seasonMultiplier = plot.greenhouse ? 1 : (cropData.seasonBonus?.[season] ?? 1);
+            const toolMultiplier = effectiveToolStats.speedBoost;
+            const fertilizerBoost = plot.fertilized ? 1.25 : 1;
 
-          const adjustedGrowTime = (cropData.growTime * 60000)
-            / (weatherMultiplier * toolMultiplier * fertilizerBoost * seasonMultiplier);
+            const adjustedGrowTime = (cropData.growTime * 60000)
+              / (weatherMultiplier * toolMultiplier * fertilizerBoost * seasonMultiplier);
 
-          if (now - plot.plantTime >= adjustedGrowTime && !plot.ready) {
-            addNotification(`${cropData.emoji} ${cropData.name} 成熟了！`, { type: 'success' });
-            return { ...plot, ready: true };
+            if (now - plot.plantTime >= adjustedGrowTime && !plot.ready) {
+              addNotification(`${cropData.emoji} ${cropData.name} 成熟了！`, { type: 'success' });
+              return { ...plot, ready: true };
+            }
           }
-        }
-        return plot;
-      }));
+          return plot;
+        });
+        stateRef.current.farm = updatedFarm;
+        return updatedFarm;
+      });
     }, 5000);
 
     return () => clearInterval(growTimer);

--- a/src/FarmGame.jsx
+++ b/src/FarmGame.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import {
   Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer,
-  Building, Star, Leaf, Seedling, Plus, Minus, ChevronRight, Wind, Factory
+  Building, Star, Leaf, Seedling, Plus, Minus, ChevronRight, Wind, Factory, ScrollText
 } from 'lucide-react'
 
 /** ---------- 基礎資料 ---------- */
@@ -26,21 +26,198 @@ const ANIMALS = {
 }
 
 const BUILDINGS = {
-  barn:         { name: '穀倉',      price: 1000, emoji: '🏚️', description: '容納牛羊，提升產量', boost: 1.2 },
-  chickenCoop:  { name: '雞舍',      price: 500,  emoji: '🏠', description: '專門養雞，提升產蛋率', boost: 1.3 },
-  dogHouse:     { name: '狗屋',      price: 300,  emoji: '🏘️', description: '狗狗的溫馨小窩',    boost: 1.1 },
-  catHouse:     { name: '貓屋',      price: 250,  emoji: '🏡', description: '貓咪的舒適居所',    boost: 1.1 },
-  pigPen:       { name: '豬圈',      price: 400,  emoji: '🏗️', description: '豬豬的泥土樂園',    boost: 1.2 },
-  pond:         { name: '池塘',      price: 600,  emoji: '🌊', description: '水鳥的天堂',        boost: 1.3 },
-  rabbitHutch:  { name: '兔籠',      price: 200,  emoji: '📦', description: '兔子的安全小屋',    boost: 1.2 },
-  greenhouse:   { name: '溫室',      price: 2000, emoji: '🏢', description: '不受天氣影響的種植空間', boost: 1.5 },
-  silo:         { name: '筒倉',      price: 800,  emoji: '🗼', description: '儲存更多作物',      boost: 1.0 },
-  windmill:     { name: '風車',      price: 1500, emoji: '🌪️', description: '產生額外收入',      boost: 1.0 },
-  sprinkler:    { name: '自動灑水器', price: 650,  emoji: '🚿', description: '每天自動澆灌作物，並降低澆水體力消耗', boost: 1.0 },
+  barn: {
+    name: '穀倉',
+    emoji: '🏚️',
+    description: '容納牛羊，提升產量',
+    levels: [
+      { cost: 1000, boost: 1.2, description: '基本穀倉，讓大型牲畜心情更穩定。' },
+      { cost: 1600, boost: 1.35, description: '擴建料槽與保溫設備，提升產量。' },
+      { cost: 2300, boost: 1.5, description: '自動飼料管理，讓牛羊保持高產。' },
+    ],
+    modules: [
+      {
+        id: 'autoGroomer',
+        name: '自動梳理機',
+        cost: 1800,
+        requirementLevel: 2,
+        description: '每天早晨為畜舍動物加值幸福度。',
+        effect: 'autoGroom',
+      },
+    ],
+  },
+  chickenCoop: {
+    name: '雞舍',
+    emoji: '🏠',
+    description: '專門養雞，提升產蛋率',
+    levels: [
+      { cost: 500, boost: 1.3, description: '簡易雞舍，改善產量。' },
+      { cost: 900, boost: 1.45, description: '加裝溫燈與自動餵食。' },
+    ],
+    modules: [],
+  },
+  dogHouse: {
+    name: '狗屋',
+    emoji: '🏘️',
+    description: '狗狗的溫馨小窩',
+    levels: [
+      { cost: 300, boost: 1.1, description: '遮風避雨的小屋。' },
+      { cost: 520, boost: 1.25, description: '加裝玩具與暖墊。' },
+    ],
+    modules: [],
+  },
+  catHouse: {
+    name: '貓屋',
+    emoji: '🏡',
+    description: '貓咪的舒適居所',
+    levels: [
+      { cost: 250, boost: 1.1, description: '柔軟的貓窩。' },
+      { cost: 480, boost: 1.22, description: '加裝貓跳台與暖燈。' },
+    ],
+    modules: [],
+  },
+  pigPen: {
+    name: '豬圈',
+    emoji: '🏗️',
+    description: '豬豬的泥土樂園',
+    levels: [
+      { cost: 400, boost: 1.2, description: '穩固圍欄與泥地。' },
+      { cost: 720, boost: 1.32, description: '自動清潔泥池，減少異味。' },
+    ],
+    modules: [],
+  },
+  pond: {
+    name: '池塘',
+    emoji: '🌊',
+    description: '水鳥的天堂',
+    levels: [
+      { cost: 600, boost: 1.3, description: '自然池塘，吸引水鳥。' },
+      { cost: 980, boost: 1.45, description: '擴建棲木與遮蔭。' },
+    ],
+    modules: [],
+  },
+  rabbitHutch: {
+    name: '兔籠',
+    emoji: '📦',
+    description: '兔子的安全小屋',
+    levels: [
+      { cost: 200, boost: 1.2, description: '堅固木籠保護兔子。' },
+      { cost: 420, boost: 1.32, description: '增設運動空間與食槽。' },
+    ],
+    modules: [],
+  },
+  greenhouse: {
+    name: '溫室',
+    emoji: '🏢',
+    description: '不受天氣影響的種植空間',
+    levels: [
+      { cost: 2000, description: '所有地塊獲得溫室保護，避免天氣損害。', greenhouseCoverage: true },
+      { cost: 3200, description: '氣候控制升級，減緩病蟲害與土壤衰退。', greenhouseCoverage: true, soilDecayReduction: 0.25 },
+    ],
+    modules: [
+      {
+        id: 'mistSystem',
+        name: '自動噴霧系統',
+        cost: 1400,
+        requirementLevel: 2,
+        description: '每天清晨自動澆灌溫室地塊，並帶來微量濕潤加成。',
+        effect: 'autoGreenhouseWater',
+      },
+    ],
+  },
+  silo: {
+    name: '筒倉',
+    emoji: '🗼',
+    description: '儲存更多作物',
+    levels: [
+      { cost: 800, storageBonus: 0.05, description: '擴充倉儲，增加出售加成。' },
+      { cost: 1300, storageBonus: 0.08, description: '裝設冷藏系統，讓作物保持新鮮。' },
+    ],
+    modules: [],
+  },
+  windmill: {
+    name: '風車',
+    emoji: '🌪️',
+    description: '產生額外收入',
+    levels: [
+      { cost: 1500, income: 50, description: '基礎風車，每日產出 50 金幣。' },
+      { cost: 2200, income: 90, description: '強化風葉，每日產出 90 金幣。' },
+      { cost: 3000, income: 140, description: '全自動風車系統，提供 140 金幣。' },
+    ],
+    modules: [
+      {
+        id: 'powerGrid',
+        name: '電力連結模組',
+        cost: 1800,
+        requirementLevel: 2,
+        description: '啟動加工廠，讓所有作物售價額外 +5%。',
+        effect: 'marketBoost',
+      },
+    ],
+  },
+  sprinkler: {
+    name: '自動灑水器',
+    emoji: '🚿',
+    description: '每天自動澆灌作物，並降低澆水體力消耗',
+    levels: [
+      { cost: 650, waterEnergyCost: 2, plantEnergyCost: 5, description: '減少澆水與種植的體力消耗。' },
+      { cost: 1400, waterEnergyCost: 0, plantEnergyCost: 3, autoMorningWater: true, description: '黎明自動灌溉並再降低體力需求。' },
+      { cost: 2200, waterEnergyCost: 0, plantEnergyCost: 1, autoMorningWater: true, description: '感測土壤狀態，自動調整澆灌效率。' },
+    ],
+    modules: [
+      {
+        id: 'fertInjector',
+        name: '施肥注入器',
+        cost: 1600,
+        requirementLevel: 2,
+        description: '澆水時自動施肥（消耗 1 份肥料）。',
+        effect: 'autoFertilize',
+      },
+    ],
+  },
 }
 
 const WEATHER_TYPES = ['sunny', 'rainy', 'cloudy', 'storm', 'snow']
 const SEASONS = ['spring','summer','autumn','winter']
+
+const STORY_QUESTS = [
+  {
+    id: 'welcome',
+    title: '新的開始',
+    description: '收成 3 次作物並建造第一棟設施，熟悉農場節奏。',
+    requirements: [
+      { type: 'harvest', target: 3, description: '收成 3 次作物' },
+      { type: 'buildingTotal', target: 1, description: '建造任一棟建築' },
+    ],
+    rewards: { money: 200, fertilizer: 3 },
+  },
+  {
+    id: 'automation',
+    title: '自動化藍圖',
+    description: '透過升級灑水器和模組化插件，打造半自動農場。',
+    requirements: [
+      { type: 'buildingLevel', building: 'sprinkler', level: 2, description: '灑水器升級至等級 2' },
+      { type: 'module', building: 'sprinkler', module: 'fertInjector', description: '安裝施肥注入器模組' },
+    ],
+    rewards: { money: 400, fertilizer: 5 },
+  },
+  {
+    id: 'windFactory',
+    title: '風之工坊',
+    description: '讓風車帶動加工廠，同時維持健康土壤與作物品質。',
+    requirements: [
+      { type: 'buildingLevel', building: 'windmill', level: 2, description: '風車升級至等級 2' },
+      { type: 'module', building: 'windmill', module: 'powerGrid', description: '安裝電力連結模組' },
+      { type: 'soilQuality', target: 75, description: '平均土壤肥力達到 75 以上' },
+    ],
+    rewards: { money: 600, fertilizer: 8 },
+  },
+]
+
+const DEFAULT_STORY_STATE = {
+  activeId: STORY_QUESTS[0].id,
+  completed: [],
+}
 
 /** ---------- 小工具 ---------- */
 const clamp = (v, min, max) => Math.max(min, Math.min(max, v))
@@ -74,7 +251,17 @@ const FarmGame = () => {
   // 農地
   const [farm, setFarm] = useState(
     Array(25).fill().map((_, i) => ({
-      id: i, crop: null, plantTime: null, watered: false, fertilized: false, greenhouse: false, ready: false
+      id: i,
+      crop: null,
+      plantTime: null,
+      watered: false,
+      fertilized: false,
+      greenhouse: false,
+      ready: false,
+      soilQuality: 70,
+      disease: 0,
+      restingDays: 0,
+      lastCrop: null,
     }))
   )
 
@@ -91,6 +278,128 @@ const FarmGame = () => {
   const [showBuildingShop, setShowBuildingShop] = useState(false)
   const [notifications, setNotifications] = useState([])
   const [speed, setSpeed] = useState(1) // 1x/2x/4x
+  const [showQuestModal, setShowQuestModal] = useState(false)
+  const [storyState, setStoryState] = useState(DEFAULT_STORY_STATE)
+  const [storyMetrics, setStoryMetrics] = useState({ harvests: 0 })
+
+  const normalizePlot = (plot, idx) => ({
+    id: plot?.id ?? idx,
+    crop: plot?.crop ?? null,
+    plantTime: plot?.plantTime ?? null,
+    watered: Boolean(plot?.watered),
+    fertilized: Boolean(plot?.fertilized),
+    greenhouse: Boolean(plot?.greenhouse),
+    ready: Boolean(plot?.ready),
+    soilQuality: clamp(typeof plot?.soilQuality === 'number' ? plot.soilQuality : 70, 0, 100),
+    disease: clamp(typeof plot?.disease === 'number' ? plot.disease : 0, 0, 100),
+    restingDays: Math.max(0, plot?.restingDays ?? 0),
+    lastCrop: plot?.lastCrop ?? null,
+  })
+
+  const normalizeBuildings = (raw = {}) => {
+    const formatted = {}
+    Object.entries(raw || {}).forEach(([key, value]) => {
+      const def = BUILDINGS[key]
+      if (!def) return
+
+      if (typeof value === 'boolean') {
+        if (value) {
+          formatted[key] = { level: 1, modules: [] }
+        }
+        return
+      }
+
+      const level = clamp(typeof value?.level === 'number' ? value.level : (value ? 1 : 0), 0, def.levels.length)
+      const modules = Array.isArray(value?.modules)
+        ? value.modules.filter(id => def.modules.some(m => m.id === id))
+        : []
+
+      if (level > 0 || modules.length > 0) {
+        formatted[key] = { level, modules }
+      }
+    })
+    return formatted
+  }
+
+  const getBuildingLevel = useCallback((type) => buildings[type]?.level || 0, [buildings])
+  const hasModule = useCallback((type, moduleId) => !!buildings[type]?.modules?.includes(moduleId), [buildings])
+
+  const getWaterEnergyCost = useCallback(() => {
+    const level = getBuildingLevel('sprinkler')
+    if (!level) return 5
+    return BUILDINGS.sprinkler.levels[level - 1]?.waterEnergyCost ?? 5
+  }, [getBuildingLevel])
+
+  const getPlantEnergyCost = useCallback(() => {
+    const level = getBuildingLevel('sprinkler')
+    if (!level) return 10
+    return BUILDINGS.sprinkler.levels[level - 1]?.plantEnergyCost ?? 10
+  }, [getBuildingLevel])
+
+  const getSiloMultiplier = useCallback(() => {
+    const level = getBuildingLevel('silo')
+    if (!level) return 1
+    return 1 + (BUILDINGS.silo.levels[level - 1]?.storageBonus || 0)
+  }, [getBuildingLevel])
+
+  const averageSoilQuality = useMemo(() => {
+    if (!farm.length) return 0
+    const total = farm.reduce((acc, plot) => acc + (plot.soilQuality || 0), 0)
+    return Math.round(total / farm.length)
+  }, [farm])
+
+  const isRequirementMet = useCallback((req) => {
+    switch (req.type) {
+      case 'harvest':
+        return (storyMetrics.harvests || 0) >= (req.target || 0)
+      case 'buildingTotal':
+        return Object.values(buildings).filter(b => (b?.level || 0) > 0).length >= (req.target || 0)
+      case 'buildingLevel':
+        return getBuildingLevel(req.building) >= (req.level || 0)
+      case 'module':
+        return hasModule(req.building, req.module)
+      case 'soilQuality':
+        return averageSoilQuality >= (req.target || 0)
+      default:
+        return false
+    }
+  }, [averageSoilQuality, buildings, getBuildingLevel, hasModule, storyMetrics])
+
+  const evaluateStoryProgress = useCallback(() => {
+    setStoryState(prev => {
+      if (!prev.activeId) return prev
+      const questIndex = STORY_QUESTS.findIndex(q => q.id === prev.activeId)
+      const quest = STORY_QUESTS[questIndex]
+      if (!quest) return prev
+      if (prev.completed.includes(quest.id)) return prev
+
+      const satisfied = quest.requirements.every(isRequirementMet)
+
+      if (!satisfied) return prev
+
+      if (quest.rewards?.money) setMoney(m => m + quest.rewards.money)
+      if (quest.rewards?.fertilizer) setFertilizer(f => f + quest.rewards.fertilizer)
+      addNotification(`劇情任務完成：${quest.title}！`)
+
+      const nextQuest = STORY_QUESTS[questIndex + 1]
+      if (nextQuest) {
+        addNotification(`新任務解鎖：${nextQuest.title}`)
+      }
+      return {
+        activeId: nextQuest?.id || null,
+        completed: [...prev.completed, quest.id],
+      }
+    })
+  }, [addNotification, isRequirementMet, setFertilizer, setMoney])
+
+  useEffect(() => {
+    evaluateStoryProgress()
+  }, [evaluateStoryProgress])
+
+  const activeQuest = useMemo(
+    () => STORY_QUESTS.find(q => q.id === storyState.activeId),
+    [storyState.activeId]
+  )
 
   /** -------- 通知 ------- */
   const addNotification = useCallback((message) => {
@@ -119,11 +428,32 @@ const FarmGame = () => {
       setInventory(s.inventory ?? inventory)
       setSeedBag(s.seedBag ?? seedBag)
       setFertilizer(s.fertilizer ?? 0)
-      setFarm(s.farm ?? farm)
-      setAnimals(s.animals ?? [])
-      setBuildings(s.buildings ?? {})
+
+      const loadedFarm = Array.isArray(s.farm) ? s.farm : farm
+      const normalizedFarm = loadedFarm.map((p, idx) => normalizePlot(p, idx))
+      const normalizedBuildings = normalizeBuildings(s.buildings ?? {})
+      const greenhouseLevel = normalizedBuildings.greenhouse?.level || 0
+      const farmWithGreenhouse = greenhouseLevel
+        ? normalizedFarm.map(plot => ({ ...plot, greenhouse: true }))
+        : normalizedFarm
+
+      setFarm(farmWithGreenhouse)
+      setAnimals((s.animals ?? []).map(animal => ({
+        ...animal,
+        happiness: clamp(typeof animal?.happiness === 'number' ? animal.happiness : 50, 0, 100),
+      })))
+      setBuildings(normalizedBuildings)
       setMarket(s.market ?? market)
       setSpeed(s.speed ?? 1)
+      setStoryState(s.storyState ? {
+        activeId: s.storyState.activeId && STORY_QUESTS.some(q => q.id === s.storyState.activeId)
+          ? s.storyState.activeId
+          : DEFAULT_STORY_STATE.activeId,
+        completed: Array.isArray(s.storyState.completed) ? s.storyState.completed : [],
+      } : DEFAULT_STORY_STATE)
+      setStoryMetrics({
+        harvests: s.storyMetrics?.harvests ?? 0,
+      })
       addNotification('讀取存檔完成')
     } catch(e) {
       console.error(e)
@@ -136,12 +466,12 @@ const FarmGame = () => {
     const id = setTimeout(() => {
       const s = {
         money, energy, level, experience, time, day, season, weather, weatherDuration,
-        inventory, seedBag, fertilizer, farm, animals, buildings, market, speed
+        inventory, seedBag, fertilizer, farm, animals, buildings, market, speed, storyState, storyMetrics
       }
       localStorage.setItem('farm-save-v2', JSON.stringify(s))
     }, 400)
     return () => clearTimeout(id)
-  }, [money, energy, level, experience, time, day, season, weather, weatherDuration, inventory, seedBag, fertilizer, farm, animals, buildings, market, speed])
+  }, [money, energy, level, experience, time, day, season, weather, weatherDuration, inventory, seedBag, fertilizer, farm, animals, buildings, market, speed, storyState, storyMetrics])
 
   /** -------- 天氣系統 -------- */
   useEffect(() => {
@@ -212,22 +542,64 @@ const FarmGame = () => {
           // 動物每日收入 & 情緒變化
           setAnimals(prev => prev.map(animal => {
             const shelter = ANIMALS[animal.type].shelter
-            const hasB = buildings[shelter]
-            const boost = hasB ? BUILDINGS[shelter].boost : 1
+            const shelterLevel = getBuildingLevel(shelter)
+            const levelConfig = shelterLevel ? BUILDINGS[shelter].levels[shelterLevel - 1] : null
+            const boost = levelConfig?.boost ?? 1
             const income = int(ANIMALS[animal.type].income * boost * (animal.happiness / 100))
             if (animal.happiness > 20 && income > 0) {
               setMoney(m => m + income)
               addNotification(`${animal.name} 產生了 $${income}！`)
             }
-            return { ...animal, happiness: Math.max(0, animal.happiness - 12) }
+            let nextHappiness = Math.max(0, animal.happiness - 12)
+            if (shelter === 'barn' && hasModule('barn', 'autoGroomer') && shelterLevel) {
+              nextHappiness = clamp(nextHappiness + 8, 0, 100)
+            }
+            return { ...animal, happiness: nextHappiness }
           }))
 
-          // 風車收入
-          if (buildings.windmill) {
-            const windmillIncome = 50
-            setMoney(m => m + windmillIncome)
-            addNotification(`🌪️ 風車產生了 $${windmillIncome}！`)
+          // 每日風車收入
+          const windmillLevel = getBuildingLevel('windmill')
+          if (windmillLevel) {
+            const income = BUILDINGS.windmill.levels[windmillLevel - 1]?.income || 0
+            if (income > 0) {
+              setMoney(m => m + income)
+              addNotification(`🌪️ 風車產生了 $${income}！`)
+            }
           }
+
+          // 自動澆灌與土壤調整
+          const sprinklerLevel = getBuildingLevel('sprinkler')
+          const sprinklerConfig = sprinklerLevel ? BUILDINGS.sprinkler.levels[sprinklerLevel - 1] : null
+          const greenhouseLevelNow = getBuildingLevel('greenhouse')
+          const greenhouseConfig = greenhouseLevelNow ? BUILDINGS.greenhouse.levels[greenhouseLevelNow - 1] : null
+
+          setFarm(prev => prev.map(plot => {
+            const resting = plot.crop ? 0 : plot.restingDays + 1
+            const repeated = plot.lastCrop && plot.lastCrop === plot.crop && plot.crop
+            const baseDecay = plot.crop ? 4 + (repeated ? 4 : 0) : -3
+            const adjustedDecay = baseDecay * (1 - (greenhouseConfig?.soilDecayReduction || 0))
+            const soilQuality = clamp(plot.soilQuality - adjustedDecay, 0, 100)
+            const diseaseDelta = plot.crop
+              ? (repeated ? 10 : 4)
+              : -8
+            const disease = clamp(plot.disease + diseaseDelta, 0, 100)
+
+            let watered = plot.watered
+            if (plot.crop && sprinklerConfig?.autoMorningWater) {
+              watered = true
+            }
+            if (plot.crop && plot.greenhouse && hasModule('greenhouse', 'mistSystem')) {
+              watered = true
+            }
+
+            return {
+              ...plot,
+              watered,
+              soilQuality,
+              disease,
+              restingDays: resting,
+            }
+          }))
 
           return 6 // 早上 6 點
         }
@@ -236,7 +608,7 @@ const FarmGame = () => {
     }, msPerHour)
 
     return () => clearInterval(timer)
-  }, [addNotification, buildings, season, speed])
+  }, [addNotification, buildings, getBuildingLevel, hasModule, season, speed])
 
   /** -------- 作物成長（每 5s 檢查一次，受 weather / 溫室 / 施肥） -------- */
   useEffect(() => {
@@ -260,6 +632,14 @@ const FarmGame = () => {
           // 施肥（加速）
           if (plot.fertilized) mult *= 1.25
 
+          const soilBonus = clamp((plot.soilQuality - 70) / 150, -0.4, 0.6)
+          mult *= 1 + soilBonus
+          const diseasePenalty = clamp(1 - (plot.disease || 0) / 160, 0.4, 1)
+          mult *= diseasePenalty
+          if (plot.greenhouse && hasModule('greenhouse', 'mistSystem')) {
+            mult *= 1.05
+          }
+
           const needMs = (crop.growTime * 60000) / mult
           if (!plot.ready && now - plot.plantTime >= needMs) {
             addNotification(`${crop.emoji} ${crop.name} 成熟了！`)
@@ -271,7 +651,7 @@ const FarmGame = () => {
     }, 5000 / speed)
 
     return () => clearInterval(growTimer)
-  }, [addNotification, speed, weather])
+  }, [addNotification, hasModule, speed, weather])
 
   /** -------- 升級 -------- */
   useEffect(() => {
@@ -310,12 +690,24 @@ const FarmGame = () => {
   const plantSeed = (plotId) => {
     if (!selectedSeed) return
     if (seedBag[selectedSeed] <= 0) return addNotification('該種子庫存不足！')
-    const energyCost = buildings.sprinkler ? 5 : 10
+    const plot = farm.find(p => p.id === plotId)
+    if (!plot || plot.crop) return
+    const energyCost = getPlantEnergyCost()
     if (energy < energyCost) return addNotification('體力不足！')
+
+    if (plot.lastCrop === selectedSeed && plot.restingDays < 2) {
+      addNotification('這塊土地剛種過相同作物，肥力下降較快！')
+    }
+    if (plot.soilQuality < 40) {
+      addNotification('土地肥力偏低，作物可能生長較慢。')
+    }
+    if (plot.disease > 60) {
+      addNotification('此地塊病蟲害嚴重，建議先休耕或輪作。')
+    }
 
     setFarm(prev => prev.map(p =>
       p.id === plotId && !p.crop
-        ? { ...p, crop: selectedSeed, plantTime: Date.now(), watered: false, fertilized: false, ready:false }
+        ? { ...p, crop: selectedSeed, plantTime: Date.now(), watered: false, fertilized: false, ready:false, restingDays: 0 }
         : p
     ))
     setSeedBag(b => ({ ...b, [selectedSeed]: b[selectedSeed]-1 }))
@@ -329,7 +721,12 @@ const FarmGame = () => {
     if (energy < 5) return addNotification('體力不足！')
     setFarm(prev => prev.map(p =>
       p.id === plotId && p.crop && !p.fertilized
-        ? { ...p, fertilized: true }
+        ? {
+            ...p,
+            fertilized: true,
+            soilQuality: clamp(p.soilQuality + 6, 0, 100),
+            disease: clamp(p.disease - 4, 0, 100),
+          }
         : p
     ))
     setFertilizer(f => f - 1)
@@ -346,9 +743,18 @@ const FarmGame = () => {
     let bonus = 1
     if (plot.watered) bonus *= 1.2
     if (plot.fertilized) bonus *= 1.3
-    if (plot.greenhouse) bonus *= 1.15
-    if (buildings.silo) bonus *= 1.05
+    const greenhouseLevel = getBuildingLevel('greenhouse')
+    if (plot.greenhouse) {
+      const greenhouseBonus = greenhouseLevel ? 1.1 + greenhouseLevel * 0.05 : 1.15
+      bonus *= greenhouseBonus
+    }
+    bonus *= getSiloMultiplier()
     if (!plot.greenhouse) bonus *= (data.weatherBonus[weather] || 1)
+    if (hasModule('windmill', 'powerGrid')) bonus *= 1.05
+    const soilYield = clamp(1 + (plot.soilQuality - 70) / 180, 0.7, 1.45)
+    bonus *= soilYield
+    const diseasePenalty = clamp(1 - (plot.disease || 0) / 140, 0.5, 1)
+    bonus *= diseasePenalty
     bonus *= (market[crop] || 1) // 市場價格
 
     const sellPrice = int(data.sellPrice * bonus)
@@ -356,18 +762,51 @@ const FarmGame = () => {
     setMoney(m => m + sellPrice)
     setInventory(inv => ({ ...inv, [crop]: inv[crop] + 1 }))
     setExperience(e => e + 10)
-    setFarm(prev => prev.map(p => p.id === plotId ? { ...p, crop:null, plantTime:null, watered:false, fertilized:false, ready:false } : p))
+    const greenhouseConfig = greenhouseLevel
+      ? BUILDINGS.greenhouse.levels[greenhouseLevel - 1]
+      : null
+    setFarm(prev => prev.map(p => {
+      if (p.id !== plotId) return p
+      const rotationPenalty = p.lastCrop === crop ? 8 : 5
+      const relief = p.fertilized ? 4 : 0
+      const soilDecay = (rotationPenalty - relief) * (1 - (greenhouseConfig?.soilDecayReduction || 0))
+      const newSoil = clamp(p.soilQuality - soilDecay, 0, 100)
+      const disease = clamp(p.disease + (p.lastCrop === crop ? 14 : 6) - (p.fertilized ? 4 : 0), 0, 100)
+      return {
+        ...p,
+        crop: null,
+        plantTime: null,
+        watered: false,
+        fertilized: false,
+        ready: false,
+        soilQuality: newSoil,
+        disease,
+        lastCrop: crop,
+        restingDays: 0,
+      }
+    }))
+    setStoryMetrics(prev => ({ ...prev, harvests: (prev.harvests || 0) + 1 }))
     addNotification(`收成 ${data.emoji}，收入 $${sellPrice}`)
   }
 
   const waterPlot = (plotId) => {
-    const energyCost = buildings.sprinkler ? 1 : 5
+    const energyCost = getWaterEnergyCost()
     if (energy < energyCost) return addNotification('體力不足！')
+    let autoFertilized = false
+    let canAutoFertilize = hasModule('sprinkler', 'fertInjector') && fertilizer > 0
     setFarm(prev => prev.map(p =>
       p.id === plotId && p.crop && !p.watered
-        ? { ...p, watered: true }
+        ? {
+            ...p,
+            watered: true,
+            fertilized: p.fertilized || (canAutoFertilize ? (autoFertilized = true) : false),
+          }
         : p
     ))
+    if (autoFertilized) {
+      setFertilizer(f => Math.max(0, f - 1))
+      addNotification('灑水器自動施肥完成！')
+    }
     setEnergy(e => clamp(e - energyCost, 0, 100))
     addNotification('澆水完成！')
   }
@@ -385,18 +824,64 @@ const FarmGame = () => {
     addNotification(`購買了 ${ANIMALS[animalType].emoji} ${ANIMALS[animalType].name}！`)
   }
 
-  const buyBuilding = (buildingType) => {
-    if (buildings[buildingType]) return addNotification('已擁有此建築！')
-    const price = BUILDINGS[buildingType].price
-    if (money < price) return addNotification('金錢不足！')
-    setMoney(m => m - price)
-    setBuildings(b => ({ ...b, [buildingType]: true }))
+  const upgradeBuilding = (buildingType) => {
+    const info = BUILDINGS[buildingType]
+    if (!info) return
+    const currentLevel = getBuildingLevel(buildingType)
+    if (currentLevel >= info.levels.length) return addNotification('已達最高等級！')
+    const nextLevel = info.levels[currentLevel]
+    if (!nextLevel) return
+    if (money < nextLevel.cost) return addNotification('金錢不足！')
+
+    setMoney(m => m - nextLevel.cost)
+    setBuildings(prev => {
+      const prevData = prev[buildingType] || { level: 0, modules: [] }
+      const updated = {
+        ...prev,
+        [buildingType]: {
+          level: currentLevel + 1,
+          modules: prevData.modules || [],
+        },
+      }
+      return updated
+    })
 
     if (buildingType === 'greenhouse') {
-      setFarm(prev => prev.map(p => (p.greenhouse ? p : { ...p, greenhouse: true })))
+      setFarm(prev => prev.map(p => ({ ...p, greenhouse: true })))
     }
+
     setShowBuildingShop(false)
-    addNotification(`建造了 ${BUILDINGS[buildingType].emoji} ${BUILDINGS[buildingType].name}！`)
+    addNotification(`${currentLevel ? '升級' : '建造'} ${info.emoji} ${info.name}（Lv.${currentLevel + 1}）！`)
+  }
+
+  const purchaseModule = (buildingType, moduleId) => {
+    const info = BUILDINGS[buildingType]
+    if (!info) return
+    const moduleInfo = info.modules.find(m => m.id === moduleId)
+    if (!moduleInfo) return
+    const level = getBuildingLevel(buildingType)
+    if (!level) return addNotification('請先建造並升級此建築！')
+    if (level < (moduleInfo.requirementLevel || 1)) {
+      return addNotification('需要更高等級才能安裝此模組！')
+    }
+    if (hasModule(buildingType, moduleId)) {
+      return addNotification('已安裝此模組！')
+    }
+    if (money < moduleInfo.cost) return addNotification('金錢不足！')
+
+    setMoney(m => m - moduleInfo.cost)
+    setBuildings(prev => {
+      const prevData = prev[buildingType] || { level: level, modules: [] }
+      const modules = [...new Set([...(prevData.modules || []), moduleId])]
+      return {
+        ...prev,
+        [buildingType]: {
+          level: prevData.level || level,
+          modules,
+        },
+      }
+    })
+    addNotification(`安裝了 ${moduleInfo.name}！`)
   }
 
   const feedAnimal = (animalId) => {
@@ -427,7 +912,17 @@ const FarmGame = () => {
     setFarm(prev => [
       ...prev,
       ...Array(5).fill().map((_, i) => ({
-        id: prev.length + i, crop:null, plantTime:null, watered:false, fertilized:false, greenhouse:false, ready:false
+        id: prev.length + i,
+        crop:null,
+        plantTime:null,
+        watered:false,
+        fertilized:false,
+        greenhouse: getBuildingLevel('greenhouse') > 0,
+        ready:false,
+        soilQuality: 70,
+        disease: 0,
+        restingDays: 0,
+        lastCrop: null,
       }))
     ])
     addNotification('擴建農地 +5 格！')
@@ -499,6 +994,13 @@ const FarmGame = () => {
               </button>
             ))}
           </div>
+          <button
+            onClick={()=>setShowQuestModal(true)}
+            className="ml-3 flex items-center gap-1 bg-amber-500 hover:bg-amber-600 text-black px-3 py-1 rounded text-sm"
+          >
+            <ScrollText className="w-4 h-4"/>
+            <span>{activeQuest ? activeQuest.title : '劇情任務'}</span>
+          </button>
         </div>
 
         <div className="flex items-center gap-4">
@@ -506,6 +1008,10 @@ const FarmGame = () => {
           <div className="flex items-center gap-1"><span>{getWeatherIcon()}</span><span className="text-sm">{getWeatherName(weather)}</span></div>
           <span className="capitalize text-sm">{getSeasonName(season)}</span>
           <span className="text-sm">第{day}天</span>
+          <div className="flex items-center gap-1 text-sm text-green-100">
+            <Seedling className="w-4 h-4 text-green-200"/>
+            <span>平均肥力 {averageSoilQuality}</span>
+          </div>
         </div>
       </div>
 
@@ -539,7 +1045,7 @@ const FarmGame = () => {
                     plot.crop ? (plot.ready ? 'bg-green-200 border-green-400 animate-pulse'
                                             : 'bg-yellow-100 border-yellow-400')
                               : 'bg-gray-100 border-gray-300 hover:bg-green-50'
-                  }`}
+                  } ${plot.soilQuality < 35 ? 'border-red-400' : plot.soilQuality > 85 ? 'border-emerald-500' : ''}`}
                   onClick={()=>{
                     if (plot.crop && plot.ready) harvestCrop(plot.id)
                     else if (!plot.crop && selectedSeed) plantSeed(plot.id)
@@ -551,7 +1057,17 @@ const FarmGame = () => {
                   }}
                 >
                   <div className="h-full flex flex-col items-center justify-center text-2xl">
-                    {plot.greenhouse && (<div className="absolute top-0 right-0 text-xs">🏢</div>)}
+                    <div className="absolute top-1 left-1 text-[10px] font-semibold bg-white/70 text-amber-700 px-1 rounded">
+                      肥 {Math.round(plot.soilQuality)}
+                    </div>
+                    <div className="absolute top-1 right-1 flex flex-col items-end gap-1 text-[10px]">
+                      {plot.greenhouse && <span className="bg-green-200 text-green-700 px-1 rounded">🏢</span>}
+                      {plot.disease > 5 && (
+                        <span className={`px-1 rounded ${plot.disease > 70 ? 'bg-red-500 text-white' : 'bg-red-100 text-red-700'}`}>
+                          病 {Math.round(plot.disease)}
+                        </span>
+                      )}
+                    </div>
                     {plot.crop ? (
                       <>
                         <div className={`transform transition-transform duration-500 ${plot.ready ? 'scale-125 animate-bounce':'scale-100'}`}>
@@ -564,6 +1080,11 @@ const FarmGame = () => {
                       </>
                     ) : (
                       selectedSeed && <div className="text-gray-400">+</div>
+                    )}
+                    {!plot.crop && plot.restingDays > 0 && (
+                      <div className="absolute bottom-1 left-1 text-[10px] text-gray-600 bg-white/70 px-1 rounded">
+                        休耕 {plot.restingDays}天
+                      </div>
                     )}
                   </div>
                 </div>
@@ -591,16 +1112,23 @@ const FarmGame = () => {
                 <h3 className="text-lg font-bold mb-3">我的動物們</h3>
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                   {animals.map(a=>{
-                    const hasB = buildings[ANIMALS[a.type].shelter]
-                    const daily = int(ANIMALS[a.type].income * (hasB?BUILDINGS[ANIMALS[a.type].shelter].boost:1))
+                    const shelter = ANIMALS[a.type].shelter
+                    const shelterLevel = getBuildingLevel(shelter)
+                    const levelInfo = shelterLevel ? BUILDINGS[shelter].levels[shelterLevel - 1] : null
+                    const hasShelter = shelterLevel > 0
+                    const daily = int(ANIMALS[a.type].income * (levelInfo?.boost ?? 1))
                     return (
                       <div key={a.id}
                         className={`rounded-lg p-3 cursor-pointer transition-colors relative ${
-                          hasB?'bg-green-100 hover:bg-green-200':'bg-blue-100 hover:bg-blue-200'
+                          hasShelter?'bg-green-100 hover:bg-green-200':'bg-blue-100 hover:bg-blue-200'
                         }`}
                         onClick={()=>feedAnimal(a.id)}
                       >
-                        {hasB && <div className="absolute top-1 right-1 text-xs">{BUILDINGS[ANIMALS[a.type].shelter].emoji}</div>}
+                        {hasShelter && (
+                          <div className="absolute top-1 right-1 text-xs">
+                            {BUILDINGS[shelter].emoji} Lv.{shelterLevel}
+                          </div>
+                        )}
                         <div className="text-center">
                           <div className="text-3xl mb-2 animate-bounce">{ANIMALS[a.type].emoji}</div>
                           <div className="text-sm font-semibold">{a.name}</div>
@@ -760,20 +1288,129 @@ const FarmGame = () => {
       {/* === 建築商店 === */}
       {showBuildingShop && (
         <Modal title="建築商店" onClose={()=>setShowBuildingShop(false)}>
-          <div className="grid grid-cols-2 gap-4 max-h-[60vh] overflow-y-auto pr-2">
-            {Object.entries(BUILDINGS).map(([key, b]) => (
-              <div key={key}
-                   className={`border rounded-lg p-4 cursor-pointer ${buildings[key]?'bg-green-100 border-green-400':'hover:bg-gray-50'}`}
-                   onClick={()=>buyBuilding(key)}>
-                <div className="text-center">
-                  <div className="text-3xl mb-2">{b.emoji}</div>
-                  <div className="font-semibold">{b.name}</div>
-                  <div className="font-bold text-green-600">{buildings[key] ? '已擁有' : `$${b.price}`}</div>
-                  <div className="text-xs text-gray-600 mt-2">{b.description}</div>
-                  {b.boost !== 1 && <div className="text-xs text-blue-600">效果加成: {Math.round(b.boost*100)}%</div>}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-h-[60vh] overflow-y-auto pr-2">
+            {Object.entries(BUILDINGS).map(([key, b]) => {
+              const owned = buildings[key]
+              const currentLevel = owned?.level || 0
+              const currentConfig = currentLevel ? b.levels[currentLevel - 1] : null
+              const nextConfig = b.levels[currentLevel] || null
+              const modulesOwned = owned?.modules || []
+              return (
+                <div key={key}
+                     className={`border rounded-lg p-4 transition-colors ${currentLevel ? 'bg-green-50 border-green-400' : 'hover:bg-gray-50'}`}>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="text-2xl">{b.emoji}</div>
+                      <div className="font-semibold mt-1">{b.name}</div>
+                    </div>
+                    <div className="text-right text-xs">
+                      <div>等級 {currentLevel}/{b.levels.length}</div>
+                      {modulesOwned.length > 0 && (
+                        <div className="text-green-600">模組: {modulesOwned.length}</div>
+                      )}
+                    </div>
+                  </div>
+                  <div className="text-xs text-gray-600 mt-2">{currentConfig?.description || b.description}</div>
+                  {nextConfig && (
+                    <div className="text-xs text-purple-700 mt-1">下一階段：{nextConfig.description}</div>
+                  )}
+                  <button
+                    className={`mt-3 w-full px-3 py-2 rounded text-sm font-semibold ${nextConfig ? 'bg-green-600 text-white hover:bg-green-700' : 'bg-gray-300 text-gray-600 cursor-not-allowed'}`}
+                    onClick={()=> nextConfig && upgradeBuilding(key)}
+                    disabled={!nextConfig}
+                  >
+                    {nextConfig ? `${currentLevel ? '升級' : '建造'} - $${nextConfig.cost}` : '已達最高等級'}
+                  </button>
+                  {b.modules.length > 0 && (
+                    <div className="mt-3 pt-3 border-t text-left space-y-2">
+                      <div className="text-xs font-semibold text-gray-700">模組化插件</div>
+                      {b.modules.map(mod => {
+                        const installed = modulesOwned.includes(mod.id)
+                        const requirementMet = currentLevel >= (mod.requirementLevel || 1)
+                        return (
+                          <div key={mod.id} className="bg-white/70 rounded p-2 text-xs flex flex-col gap-1">
+                            <div className="flex items-center justify-between">
+                              <span className="font-semibold">{mod.name}</span>
+                              <button
+                                className={`px-2 py-1 rounded ${installed ? 'bg-green-200 text-green-700 cursor-not-allowed' : requirementMet ? 'bg-blue-500 text-white hover:bg-blue-600' : 'bg-gray-200 text-gray-500 cursor-not-allowed'}`}
+                                onClick={()=> !installed && requirementMet && purchaseModule(key, mod.id)}
+                                disabled={installed || !requirementMet}
+                              >
+                                {installed ? '已安裝' : `$${mod.cost}`}
+                              </button>
+                            </div>
+                            <div className="text-[11px] text-gray-600">{mod.description}</div>
+                            {!requirementMet && !installed && (
+                              <div className="text-[11px] text-red-500">需要等級 {mod.requirementLevel}</div>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
                 </div>
+              )
+            })}
+          </div>
+        </Modal>
+      )}
+
+      {showQuestModal && (
+        <Modal title="農場故事任務" onClose={()=>setShowQuestModal(false)}>
+          <div className="space-y-4">
+            {activeQuest ? (
+              <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+                <h3 className="text-lg font-semibold text-amber-700 flex items-center gap-2">
+                  <ScrollText className="w-5 h-5"/> {activeQuest.title}
+                </h3>
+                <p className="text-sm text-amber-900 mt-1">{activeQuest.description}</p>
+                <div className="mt-3 space-y-2">
+                  {activeQuest.requirements.map((req, idx) => {
+                    const met = isRequirementMet(req)
+                    let progress = ''
+                    if (req.type === 'harvest') progress = `${Math.min(storyMetrics.harvests, req.target)}/${req.target}`
+                    if (req.type === 'buildingTotal') {
+                      const count = Object.values(buildings).filter(b => (b?.level || 0) > 0).length
+                      progress = `${Math.min(count, req.target)}/${req.target}`
+                    }
+                    if (req.type === 'buildingLevel') progress = `Lv.${getBuildingLevel(req.building)}/${req.level}`
+                    if (req.type === 'module') progress = hasModule(req.building, req.module) ? '已安裝' : '未安裝'
+                    if (req.type === 'soilQuality') progress = `${averageSoilQuality}/${req.target}`
+                    return (
+                      <div key={idx} className={`flex items-center justify-between rounded px-3 py-2 text-sm ${met ? 'bg-green-100 text-green-700' : 'bg-white'}`}>
+                        <span>{req.description}</span>
+                        <span className="text-xs text-gray-600">{progress}</span>
+                      </div>
+                    )
+                  })}
+                </div>
+                {activeQuest.rewards && (
+                  <div className="mt-3 text-xs text-amber-800">
+                    獎勵：
+                    {activeQuest.rewards.money ? `金錢 +${activeQuest.rewards.money} ` : ''}
+                    {activeQuest.rewards.fertilizer ? `肥料 +${activeQuest.rewards.fertilizer}` : ''}
+                  </div>
+                )}
               </div>
-            ))}
+            ) : (
+              <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-green-700">
+                所有故事任務皆已完成！保持農場的蓬勃發展吧。
+              </div>
+            )}
+
+            <div>
+              <h4 className="text-sm font-semibold text-gray-600 mb-2">已完成任務</h4>
+              {storyState.completed.length > 0 ? (
+                <ul className="space-y-1 text-sm text-gray-700">
+                  {storyState.completed.map(id => {
+                    const quest = STORY_QUESTS.find(q => q.id === id)
+                    return <li key={id}>✅ {quest?.title || id}</li>
+                  })}
+                </ul>
+              ) : (
+                <p className="text-sm text-gray-500">尚未完成任何劇情任務。</p>
+              )}
+            </div>
           </div>
         </Modal>
       )}

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -49,7 +49,17 @@ class Building extends BaseEntity {
 class Tool extends BaseEntity {
   constructor(
     key,
-    { name, energyReduction, speedBoost, price, upgradeCost = null, speedUpgrade = 0, energyUpgrade = 0, repeatableUpgrade = false }
+    {
+      name,
+      energyReduction,
+      speedBoost,
+      price,
+      upgradeCost = null,
+      speedUpgrade = 0,
+      energyUpgrade = 0,
+      repeatableUpgrade = false,
+      upgradeIncrement = 0,
+    }
   ) {
     super(key);
     this.name = name;
@@ -60,6 +70,7 @@ class Tool extends BaseEntity {
     this.speedUpgrade = speedUpgrade;
     this.energyUpgrade = energyUpgrade;
     this.repeatableUpgrade = repeatableUpgrade;
+    this.upgradeIncrement = upgradeIncrement;
   }
 }
 
@@ -305,6 +316,7 @@ class GameCatalog {
         upgradeCost: 2500,
         speedUpgrade: 0.15,
         repeatableUpgrade: true,
+        upgradeIncrement: 1000,
       }),
     };
 

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -391,6 +391,7 @@ export class GameEngine {
       }
 
       resultingSize = next.length;
+      this.stateRef.current.farm = next;
       return next;
     });
 
@@ -487,11 +488,16 @@ export class GameEngine {
         return true;
       }
 
-      this.setters.setFarm(prev => prev.map(p => (
-        p.id === plotId
-          ? { ...p, fertilized: true }
-          : p
-      )));
+      this.setters.setFarm(prev => {
+        const safePrev = Array.isArray(prev) ? prev : [];
+        const nextFarm = safePrev.map(p => (
+          p.id === plotId
+            ? { ...p, fertilized: true }
+            : p
+        ));
+        this.stateRef.current.farm = nextFarm;
+        return nextFarm;
+      });
       this.consumeSupply('fertilizer', { keepSelection: available > 1 });
       this.notify('施用了有機肥料，作物成長速度提升！', { type: 'success' });
       return true;
@@ -503,11 +509,16 @@ export class GameEngine {
         return true;
       }
 
-      this.setters.setFarm(prev => prev.map(p => (
-        p.id === plotId
-          ? { ...p, pest: false, pestDays: 0 }
-          : p
-      )));
+      this.setters.setFarm(prev => {
+        const safePrev = Array.isArray(prev) ? prev : [];
+        const nextFarm = safePrev.map(p => (
+          p.id === plotId
+            ? { ...p, pest: false, pestDays: 0 }
+            : p
+        ));
+        this.stateRef.current.farm = nextFarm;
+        return nextFarm;
+      });
       this.consumeSupply('pesticide', { keepSelection: available > 1 });
       this.notify('成功清除害蟲，作物恢復生長！', { type: 'success' });
       this.emitQuestEvent({ type: 'pestClear', amount: 1 });
@@ -659,20 +670,25 @@ export class GameEngine {
       [crop]: ((prev && prev[crop]) || 0) + 1,
     }));
     this.setters.setExperience(prev => prev + 10);
-    this.setters.setFarm(prev => prev.map(p => (
-      p.id === plotId
-        ? {
-            ...p,
-            crop: null,
-            plantTime: null,
-            watered: false,
-            ready: false,
-            pest: false,
-            pestDays: 0,
-            fertilized: false,
-          }
-        : p
-    )));
+    this.setters.setFarm(prev => {
+      const safePrev = Array.isArray(prev) ? prev : [];
+      const nextFarm = safePrev.map(p => (
+        p.id === plotId
+          ? {
+              ...p,
+              crop: null,
+              plantTime: null,
+              watered: false,
+              ready: false,
+              pest: false,
+              pestDays: 0,
+              fertilized: false,
+            }
+          : p
+      ));
+      this.stateRef.current.farm = nextFarm;
+      return nextFarm;
+    });
 
     this.notify(`收成了 ${CROPS[crop].emoji}！已存入倉庫（估值 $${sellPrice}）。`, { type: 'success' });
     this.emitQuestEvent({ type: 'harvest', crop, amount: 1 });
@@ -686,11 +702,16 @@ export class GameEngine {
       return;
     }
 
-    this.setters.setFarm(prev => prev.map(plot =>
-      plot.id === plotId && plot.crop && !plot.watered
-        ? { ...plot, watered: true }
-        : plot
-    ));
+    this.setters.setFarm(prev => {
+      const safePrev = Array.isArray(prev) ? prev : [];
+      const nextFarm = safePrev.map(plot =>
+        plot.id === plotId && plot.crop && !plot.watered
+          ? { ...plot, watered: true }
+          : plot
+      );
+      this.stateRef.current.farm = nextFarm;
+      return nextFarm;
+    });
 
     this.setters.setEnergy(prev => Math.max(0, prev - energyCost));
     this.notify('澆水完成！', { type: 'success' });
@@ -898,13 +919,18 @@ export class GameEngine {
     }
 
     let built = false;
-    this.setters.setFarm(prev => prev.map(plot => {
-      if (plot.id === plotId && !plot.greenhouse) {
-        built = true;
-        return { ...plot, greenhouse: true };
-      }
-      return plot;
-    }));
+    this.setters.setFarm(prev => {
+      const safePrev = Array.isArray(prev) ? prev : [];
+      const nextFarm = safePrev.map(plot => {
+        if (plot.id === plotId && !plot.greenhouse) {
+          built = true;
+          return { ...plot, greenhouse: true };
+        }
+        return plot;
+      });
+      this.stateRef.current.farm = nextFarm;
+      return nextFarm;
+    });
 
     if (!built) {
       this.notify('暫時無法建造，請確認土地是否空閒。', { type: 'warning' });

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -7,6 +7,43 @@ export const BASE_ANIMAL_CAPACITY = 6;
 export const ANIMAL_CAPACITY_STEP = 1;
 export const MAX_ANIMAL_CAPACITY = 24;
 
+export const ANIMAL_CARE_ACTIONS = {
+  playtime: {
+    key: 'playtime',
+    label: '陪牠玩耍',
+    shortLabel: '陪玩',
+    needLabel: '想玩耍',
+    description: '與動物一起玩耍可以大幅提升幸福度與羈絆，但會稍微增加飢餓感。',
+    energyCost: 6,
+    happinessBoost: 18,
+    bondBoost: 14,
+    hungerImpact: 14,
+  },
+  grooming: {
+    key: 'grooming',
+    label: '梳洗打理',
+    shortLabel: '梳洗',
+    needLabel: '想梳洗',
+    description: '細心梳洗讓動物保持乾淨舒適，降低生病風險並增加羈絆。',
+    energyCost: 5,
+    happinessBoost: 12,
+    bondBoost: 10,
+    cleanlinessBoost: 22,
+    sootheSickness: true,
+  },
+  cleanPen: {
+    key: 'cleanPen',
+    label: '清理欄舍',
+    shortLabel: '清理',
+    needLabel: '需要清理',
+    description: '整理環境讓欄舍更乾淨，恢復整潔度並讓動物更安心。',
+    energyCost: 7,
+    happinessBoost: 8,
+    bondBoost: 8,
+    cleanlinessBoost: 28,
+  },
+};
+
 export const getFarmExpansionCost = (currentPlotCount) => {
   if (currentPlotCount >= MAX_FARM_PLOTS) {
     return null;
@@ -774,6 +811,11 @@ export class GameEngine {
         sicknessDays: 0,
         name: `${animal.name}${baseIndex + index + 1}`,
         productReady: 0,
+        bond: 20,
+        cleanliness: 85,
+        careNeed: null,
+        careDays: 0,
+        lastCareTime: null,
       }));
       return [...prevList, ...additions];
     });
@@ -1176,6 +1218,124 @@ export class GameEngine {
     }
   }
 
+  careForAnimal(animalId, actionKey) {
+    const { animals = [], energy } = this.state;
+    if (!Array.isArray(animals) || animals.length === 0) {
+      this.notify('目前還沒有動物可互動。', { type: 'info' });
+      return;
+    }
+
+    const action = ANIMAL_CARE_ACTIONS[actionKey];
+    if (!action) {
+      return;
+    }
+
+    const animal = animals.find(entry => entry.id === animalId);
+    if (!animal) {
+      this.notify('找不到這隻動物。', { type: 'error' });
+      return;
+    }
+
+    if (energy < action.energyCost) {
+      this.notify('體力不足，稍作休息再來陪伴牠們吧！', { type: 'warning' });
+      return;
+    }
+
+    const animalData = ANIMALS[animal.type];
+    if (!animalData) {
+      return;
+    }
+
+    this.setters.setEnergy(prev => {
+      const updated = Math.max(0, prev - action.energyCost);
+      this.stateRef.current.energy = updated;
+      return updated;
+    });
+
+    const previousBond = animal.bond ?? 0;
+    let resolvedNeed = false;
+    let soothed = false;
+    let cleanlinessGain = 0;
+    let resultingBond = null;
+
+    this.setters.setAnimals(prev => {
+      const baseList = Array.isArray(prev) ? prev : [];
+      const nextList = baseList.map(entry => {
+        if (entry.id !== animalId) {
+          return entry;
+        }
+
+        const baseHappiness = entry.happiness ?? animalData.happiness ?? 50;
+        const baseHunger = entry.hunger ?? 60;
+        const baseBond = entry.bond ?? 0;
+        const baseCleanliness = entry.cleanliness ?? 70;
+        const hungerImpact = action.hungerImpact ?? 0;
+        const cleanlinessBoost = action.cleanlinessBoost ?? 0;
+        const needResolved = entry.careNeed === actionKey;
+
+        let nextSicknessDays = entry.sicknessDays ?? (entry.sick ? 1 : 0);
+        let nextSick = entry.sick ?? false;
+        if (action.sootheSickness && nextSick) {
+          nextSicknessDays = Math.max(0, nextSicknessDays - 1);
+          if (nextSicknessDays <= 0 || Math.random() < 0.35) {
+            nextSick = false;
+            nextSicknessDays = 0;
+            soothed = true;
+          }
+        }
+
+        const nextHappinessBase = baseHappiness + action.happinessBoost + (needResolved ? 6 : 0);
+        const nextHunger = Math.max(0, Math.min(100, baseHunger - hungerImpact));
+        const nextBond = Math.min(100, baseBond + action.bondBoost);
+        const nextCleanliness = Math.max(0, Math.min(100, baseCleanliness + cleanlinessBoost));
+        resolvedNeed = resolvedNeed || needResolved;
+        cleanlinessGain = Math.max(cleanlinessGain, Math.max(0, nextCleanliness - baseCleanliness));
+        resultingBond = nextBond;
+
+        const nextState = {
+          ...entry,
+          happiness: Math.min(100, Math.max(0, nextHappinessBase)),
+          hunger: nextHunger,
+          bond: nextBond,
+          cleanliness: nextCleanliness,
+          careNeed: needResolved ? null : entry.careNeed ?? null,
+          careDays: needResolved ? 0 : entry.careDays ?? 0,
+          lastCareTime: Date.now(),
+          sick: nextSick,
+          sicknessDays: nextSicknessDays,
+        };
+
+        return nextState;
+      });
+
+      this.stateRef.current.animals = nextList;
+      return nextList;
+    });
+
+    const actionLabel = action.shortLabel || action.label;
+    const message = resolvedNeed
+      ? `${animal.name} 得到了期待已久的${actionLabel}時間！`
+      : `與 ${animal.name} 進行了${actionLabel}，感情升溫囉！`;
+
+    this.notify(`🐾 ${message}`, { type: resolvedNeed ? 'success' : 'info' });
+
+    if (cleanlinessGain > 0 && action.cleanlinessBoost) {
+      this.notify(`${animal.name} 的欄舍煥然一新，感覺更加舒適！`, { type: 'info' });
+    }
+
+    if (soothed) {
+      this.notify(`${animal.name} 的不適大幅緩解，看起來好多了。`, { type: 'success' });
+    }
+
+    const milestones = [30, 60, 90];
+    if (resultingBond != null) {
+      const reached = milestones.filter(threshold => previousBond < threshold && resultingBond >= threshold);
+      if (reached.length > 0) {
+        this.notify(`💞 與 ${animal.name} 的羈絆提升到 ${Math.round(resultingBond)}！`, { type: 'success' });
+      }
+    }
+  }
+
   feedAnimal(animalId) {
     const { animals, money } = this.state;
     const animal = animals.find(a => a.id === animalId);
@@ -1194,16 +1354,21 @@ export class GameEngine {
     }
 
     this.setters.setMoney(prev => prev - cost);
-    this.setters.setAnimals(prev => prev.map(a =>
-      a.id === animalId
-        ? {
-            ...a,
-            happiness: Math.min(100, (a.happiness ?? ANIMALS[a.type].happiness) + 20),
-            hunger: Math.min(100, currentHunger + 40),
-            lastFed: Date.now(),
-          }
-        : a
-    ));
+    this.setters.setAnimals(prev => {
+      const nextList = prev.map(a =>
+        a.id === animalId
+          ? {
+              ...a,
+              happiness: Math.min(100, (a.happiness ?? ANIMALS[a.type].happiness) + 20),
+              hunger: Math.min(100, currentHunger + 40),
+              lastFed: Date.now(),
+              bond: Math.min(100, (a.bond ?? 0) + 4),
+            }
+          : a
+      );
+      this.stateRef.current.animals = nextList;
+      return nextList;
+    });
     this.notify(`餵食了 ${animal.name}！`, { type: 'success' });
   }
 
@@ -1224,16 +1389,21 @@ export class GameEngine {
       return;
     }
 
-    this.setters.setAnimals(prev => prev.map(a =>
-      a.id === animalId
-        ? {
-            ...a,
-            sick: false,
-            happiness: Math.min(100, (a.happiness ?? ANIMALS[a.type].happiness) + 25),
-            sicknessDays: 0,
-          }
-        : a
-    ));
+    this.setters.setAnimals(prev => {
+      const nextList = prev.map(a =>
+        a.id === animalId
+          ? {
+              ...a,
+              sick: false,
+              happiness: Math.min(100, (a.happiness ?? ANIMALS[a.type].happiness) + 25),
+              sicknessDays: 0,
+              bond: Math.min(100, (a.bond ?? 0) + 6),
+            }
+          : a
+      );
+      this.stateRef.current.animals = nextList;
+      return nextList;
+    });
 
     this.consumeSupply('medicine', { keepSelection: medicineCount > 1 });
     this.notify(`已替 ${animal.name} 使用營養劑，狀況好多了！`, { type: 'success' });
@@ -1265,11 +1435,15 @@ export class GameEngine {
     }
 
     const product = ANIMAL_PRODUCTS[animalData.product];
-    this.setters.setAnimals(prev => prev.map(entry => (
-      entry.id === animalId
-        ? { ...entry, productReady: 0, lastCollected: Date.now() }
-        : entry
-    )));
+    this.setters.setAnimals(prev => {
+      const nextList = prev.map(entry => (
+        entry.id === animalId
+          ? { ...entry, productReady: 0, lastCollected: Date.now(), bond: Math.min(100, (entry.bond ?? 0) + 2) }
+          : entry
+      ));
+      this.stateRef.current.animals = nextList;
+      return nextList;
+    });
 
     this.setters.setInventory(prev => ({
       ...prev,

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -308,8 +308,8 @@ export class GameEngine {
       return;
     }
 
-    const { money, marketPrices, inventory } = this.state;
-    const price = (marketPrices && marketPrices[seedType]) || crop.price;
+    const { money, inventory } = this.state;
+    const price = crop.price;
     const seedKey = this.getSeedKey(seedType);
     const storedSeeds = inventory?.[seedKey] || 0;
 
@@ -331,8 +331,8 @@ export class GameEngine {
     }
 
     const amount = Math.max(1, Math.floor(quantity));
-    const { money, marketPrices } = this.state;
-    const price = (marketPrices && marketPrices[seedType]) || crop.price;
+    const { money } = this.state;
+    const price = crop.price;
     const totalCost = price * amount;
 
     if (money < totalCost) {
@@ -580,7 +580,7 @@ export class GameEngine {
   }
 
   plantSeed(plotId) {
-    const { selectedSeed, tools, energy, money, marketPrices, inventory, season, farm } = this.state;
+    const { selectedSeed, tools, energy, money, inventory, season, farm } = this.state;
     if (!selectedSeed) return;
 
     const farmList = Array.isArray(farm) ? farm : [];
@@ -596,7 +596,7 @@ export class GameEngine {
       return;
     }
 
-    const price = (marketPrices && marketPrices[selectedSeed]) || CROPS[selectedSeed].price;
+    const price = CROPS[selectedSeed].price;
     const seedKey = this.getSeedKey(selectedSeed);
     const storedSeeds = inventory?.[seedKey] || 0;
     const usingStoredSeed = storedSeeds > 0;

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -229,6 +229,20 @@ export class GameEngine {
     return Math.max(0, Math.floor(raw));
   }
 
+  getToolUpgradeCost(toolKey = this.state.tools, upgradesCompleted = this.getToolUpgradeLevel(toolKey)) {
+    const tool = TOOLS[toolKey];
+    if (!tool || !tool.upgradeCost) {
+      return null;
+    }
+
+    const baseCost = Number(tool.upgradeCost) || 0;
+    const increment = Number(tool.upgradeIncrement) || 0;
+    const timesUpgraded = Math.max(0, upgradesCompleted);
+    const scaledCost = baseCost + (increment * timesUpgraded);
+
+    return Math.max(0, Math.floor(scaledCost));
+  }
+
   getEffectiveToolStats(toolKey = this.state.tools) {
     const baseTool = TOOLS[toolKey] || TOOLS.basic;
     const level = this.getToolUpgradeLevel(toolKey);
@@ -966,14 +980,14 @@ export class GameEngine {
 
     if (ownedSet.has(toolType)) {
       if (wantsUpgrade) {
-        if (!tool.upgradeCost) {
+        const currentLevel = this.getToolUpgradeLevel(toolType);
+        const cost = this.getToolUpgradeCost(toolType, currentLevel);
+        if (cost === null) {
           this.notify('這項工具無法再升級。', { type: 'info' });
           return;
         }
 
-        const currentLevel = this.getToolUpgradeLevel(toolType);
         const nextLevel = currentLevel + 1;
-        const cost = tool.upgradeCost;
         if (money < cost) {
           this.notify('金錢不足，暫時無法升級工具。', { type: 'error' });
           return;
@@ -983,15 +997,24 @@ export class GameEngine {
         const nextEnergy = (tool.energyReduction || 0) + (tool.energyUpgrade || 0) * nextLevel;
 
         this.setters.setMoney(prev => prev - cost);
+        const updateLevels = (previousLevels = {}) => {
+          const safePrev = previousLevels && typeof previousLevels === 'object' ? previousLevels : {};
+          const current = safePrev[toolType] || 0;
+          const nextLevels = { ...safePrev, [toolType]: current + 1 };
+          this.stateRef.current.toolLevels = nextLevels;
+          return nextLevels;
+        };
+
         if (typeof this.setters.setToolLevels === 'function') {
-          this.setters.setToolLevels(prev => {
-            const previous = prev && typeof prev === 'object' ? prev : {};
-            const current = previous[toolType] || 0;
-            return { ...previous, [toolType]: current + 1 };
-          });
+          this.setters.setToolLevels(prev => updateLevels(prev));
+        } else {
+          updateLevels(this.stateRef.current.toolLevels);
         }
         this.setters.setTools(toolType);
-        this.notify(`升級 ${tool.name} 至 Lv.${nextLevel + 1}！速度提升至 ${Math.round(nextSpeed * 100)}%，體力節省 ${Math.round(nextEnergy)}。`, { type: 'success' });
+        this.notify(
+          `升級 ${tool.name} 至 Lv.${nextLevel + 1}！速度提升至 ${Math.round(nextSpeed * 100)}%，體力節省 ${Math.round(nextEnergy)}。`,
+          { type: 'success' }
+        );
         return;
       }
 
@@ -1030,10 +1053,20 @@ export class GameEngine {
       this.setters.setToolLevels(prev => {
         const previous = prev && typeof prev === 'object' ? prev : {};
         if (toolType in previous) {
+          this.stateRef.current.toolLevels = previous;
           return previous;
         }
-        return { ...previous, [toolType]: 0 };
+        const nextLevels = { ...previous, [toolType]: 0 };
+        this.stateRef.current.toolLevels = nextLevels;
+        return nextLevels;
       });
+    } else {
+      const prevLevels = this.stateRef.current.toolLevels && typeof this.stateRef.current.toolLevels === 'object'
+        ? this.stateRef.current.toolLevels
+        : {};
+      if (!(toolType in prevLevels)) {
+        this.stateRef.current.toolLevels = { ...prevLevels, [toolType]: 0 };
+      }
     }
     this.setters.setShowToolShop(false);
     this.notify(`購買並裝備 ${tool.name}！`, { type: 'success' });

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -98,6 +98,13 @@ export class SaveManager {
       dynamicQuests,
       ownedTools,
       toolLevels,
+      seasonalEvents,
+      seasonalEventHistory,
+      weatherMissions,
+      weatherMissionHistory,
+      marketCommissions,
+      commissionHistory,
+      marketBoosts,
     } = this.state;
 
     const safeFarm = Array.isArray(farm) ? farm : [];
@@ -135,6 +142,13 @@ export class SaveManager {
       dynamicQuests: dynamicQuests || {},
       ownedTools: Array.isArray(ownedTools) ? ownedTools : Array.from(ownedTools || []),
       toolLevels: toolLevels && typeof toolLevels === 'object' ? { ...toolLevels } : {},
+      seasonalEvents: Array.isArray(seasonalEvents) ? seasonalEvents : [],
+      seasonalEventHistory: seasonalEventHistory && typeof seasonalEventHistory === 'object' ? { ...seasonalEventHistory } : {},
+      weatherMissions: Array.isArray(weatherMissions) ? weatherMissions : [],
+      weatherMissionHistory: weatherMissionHistory && typeof weatherMissionHistory === 'object' ? { ...weatherMissionHistory } : {},
+      marketCommissions: Array.isArray(marketCommissions) ? marketCommissions : [],
+      commissionHistory: commissionHistory && typeof commissionHistory === 'object' ? { ...commissionHistory } : {},
+      marketBoosts: marketBoosts && typeof marketBoosts === 'object' ? { ...marketBoosts } : {},
       saveTime: new Date().toISOString(),
       version: '1.1',
     };
@@ -186,6 +200,39 @@ export class SaveManager {
         ? { ...gameState.dynamicQuests }
         : {};
       this.setters.setDynamicQuests(dynamic);
+    }
+    if (typeof this.setters.setSeasonalEvents === 'function') {
+      this.setters.setSeasonalEvents(Array.isArray(gameState.seasonalEvents) ? gameState.seasonalEvents : []);
+    }
+    if (typeof this.setters.setSeasonalEventHistory === 'function') {
+      const history = gameState.seasonalEventHistory && typeof gameState.seasonalEventHistory === 'object'
+        ? { ...gameState.seasonalEventHistory }
+        : {};
+      this.setters.setSeasonalEventHistory(history);
+    }
+    if (typeof this.setters.setWeatherMissions === 'function') {
+      this.setters.setWeatherMissions(Array.isArray(gameState.weatherMissions) ? gameState.weatherMissions : []);
+    }
+    if (typeof this.setters.setWeatherMissionHistory === 'function') {
+      const history = gameState.weatherMissionHistory && typeof gameState.weatherMissionHistory === 'object'
+        ? { ...gameState.weatherMissionHistory }
+        : {};
+      this.setters.setWeatherMissionHistory(history);
+    }
+    if (typeof this.setters.setMarketCommissions === 'function') {
+      this.setters.setMarketCommissions(Array.isArray(gameState.marketCommissions) ? gameState.marketCommissions : []);
+    }
+    if (typeof this.setters.setCommissionHistory === 'function') {
+      const history = gameState.commissionHistory && typeof gameState.commissionHistory === 'object'
+        ? { ...gameState.commissionHistory }
+        : {};
+      this.setters.setCommissionHistory(history);
+    }
+    if (typeof this.setters.setMarketBoosts === 'function') {
+      const boosts = gameState.marketBoosts && typeof gameState.marketBoosts === 'object'
+        ? { ...gameState.marketBoosts }
+        : {};
+      this.setters.setMarketBoosts(boosts);
     }
     if (typeof this.setters.setOwnedTools === 'function') {
       const owned = Array.isArray(gameState.ownedTools)

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -288,6 +288,7 @@ export class SaveManager {
     }
 
     this.setters.setFarm(normalizedFarm);
+    this.stateRef.current.farm = normalizedFarm;
     const baseSupplies = { ...createDefaultSupplies(), ...(gameState.farmSupplies || {}) };
     Object.entries(normalizedInventory).forEach(([key, value]) => {
       if (key.startsWith('seed_')) {

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -1,5 +1,12 @@
 import { ANIMALS, CROPS, ANIMAL_PRODUCTS } from '../data/GameCatalog';
-import { BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BUILDING_UPGRADES } from './GameEngine';
+import {
+  BASE_ANIMAL_CAPACITY,
+  MAX_ANIMAL_CAPACITY,
+  BASE_FARM_PLOTS,
+  MAX_FARM_PLOTS,
+  BUILDING_UPGRADES,
+  ANIMAL_CARE_ACTIONS,
+} from './GameEngine';
 
 const createDefaultInventory = () => {
   const inventory = {};
@@ -304,6 +311,11 @@ export class SaveManager {
           sick: animal.sick ?? false,
           productReady: Math.max(0, Math.floor(animal.productReady || 0)),
           sicknessDays: Math.max(0, Math.floor(animal.sicknessDays ?? (animal.sick ? 1 : 0))),
+          bond: Math.max(0, Math.min(100, Math.floor(animal.bond ?? 20))),
+          cleanliness: Math.max(0, Math.min(100, Math.floor(animal.cleanliness ?? 80))),
+          careNeed: animal.careNeed && ANIMAL_CARE_ACTIONS[animal.careNeed] ? animal.careNeed : null,
+          careDays: Math.max(0, Math.floor(animal.careDays ?? 0)),
+          lastCareTime: animal.lastCareTime ?? null,
         }))
       : [];
     this.setters.setAnimals(sanitizedAnimals);


### PR DESCRIPTION
## Summary
- update all farm mutations in the game engine to write the latest plot data back to the shared state reference
- keep the farm reference in sync when expanding fields, applying supplies, harvesting, watering, or placing greenhouses to avoid phantom crops and seed usage issues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d36da595088329a99cf674c2251cc2