### PR TITLE
Add tiered planting achievements and track lifetime stats

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -720,6 +720,7 @@ const FarmGame = () => {
   const [previousMarketPrices, setPreviousMarketPrices] = useState({});
   const [marketUpdateTime, setMarketUpdateTime] = useState(null);
   const [dailyStats, setDailyStats] = useState([]);
+  const [lifetimeStats, setLifetimeStats] = useState({ cropsPlanted: 0 });
   const [automation, setAutomation] = useState({ autoWater: false, autoHarvest: false });
   const [seasonalEvents, setSeasonalEvents] = useState([]);
   const [seasonalEventHistory, setSeasonalEventHistory] = useState({});
@@ -762,6 +763,7 @@ const FarmGame = () => {
     toolLevels,
     completedAchievements,
     dailyStats,
+    lifetimeStats,
     automation,
     marketPrices,
     previousMarketPrices,
@@ -808,6 +810,7 @@ const FarmGame = () => {
       setQuestLog,
       setCompletedAchievements,
       setDailyStats,
+      setLifetimeStats,
       setAutomation,
       setMarketPrices,
       setPreviousMarketPrices,
@@ -844,6 +847,7 @@ const FarmGame = () => {
       setFarm,
       setEnergy,
       setExperience,
+      setLifetimeStats,
       setInventory,
       setFarmSupplies,
       setAnimals,
@@ -1194,10 +1198,19 @@ const FarmGame = () => {
     ACHIEVEMENTS.forEach(achievement => {
       if (!completedAchievements.has(achievement.id)) {
         let unlocked = false;
-        
+
         switch (achievement.id) {
           case 'firstPlant':
             unlocked = farm.some(plot => plot.crop);
+            break;
+          case 'planter100':
+            unlocked = (lifetimeStats?.cropsPlanted || 0) >= 100;
+            break;
+          case 'planter500':
+            unlocked = (lifetimeStats?.cropsPlanted || 0) >= 500;
+            break;
+          case 'planter1000':
+            unlocked = (lifetimeStats?.cropsPlanted || 0) >= 1000;
             break;
           case 'richFarmer':
             unlocked = money >= 10000;
@@ -1223,7 +1236,7 @@ const FarmGame = () => {
         }
       }
     });
-  }, [money, animals, buildings, level, farm, completedAchievements, addNotification]);
+  }, [money, animals, buildings, level, farm, completedAchievements, addNotification, lifetimeStats]);
 
   // 時間系統
   useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,8 @@ import {
   ANIMAL_CARE_ACTIONS,
   ANIMAL_TRAITS,
   ANIMAL_TRAIT_MAP,
+  ANIMAL_MIN_BUTCHER_AGE_DAYS,
+  pickAnimalTraitKey,
 } from './game/engine/constants';
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
@@ -528,6 +530,14 @@ const FarmGame = () => {
     setPendingAnimalName('');
   }, []);
 
+  const promptAnimalNaming = useCallback((animalId, suggestedName = '') => {
+    if (!animalId) {
+      return;
+    }
+    setRenamingAnimalId(animalId);
+    setPendingAnimalName(suggestedName || '');
+  }, []);
+
   const commitAnimalRename = useCallback(() => {
     if (!renamingAnimalId) {
       return;
@@ -790,7 +800,7 @@ const FarmGame = () => {
     if (Object.keys(commissionHistoryUpdates).length > 0) {
       setCommissionHistory(prev => ({ ...(prev || {}), ...commissionHistoryUpdates }));
     }
-  }, [addNotification, setSeasonalEvents, setSeasonalEventHistory, setWeatherMissions, setWeatherMissionHistory, setMarketCommissions, setCommissionHistory, stateRef]);
+  }, [addNotification, promptAnimalNaming, setSeasonalEvents, setSeasonalEventHistory, setWeatherMissions, setWeatherMissionHistory, setMarketCommissions, setCommissionHistory, stateRef]);
 
   useEffect(() => {
     questManager.refreshDaily(day);
@@ -959,9 +969,10 @@ const FarmGame = () => {
       setToolLevels,
       setPendingGreenhousePlacement,
       recordQuestEvent,
+      promptAnimalNaming,
     },
     notifier: addNotification,
-  }), [stateRef, addNotification, recordQuestEvent]);
+  }), [stateRef, addNotification, recordQuestEvent, promptAnimalNaming]);
 
   const sprinklerLevel = useMemo(
     () => gameEngine.getBuildingLevel(buildings, 'sprinkler'),
@@ -1657,6 +1668,8 @@ const FarmGame = () => {
                     careNeed: null,
                     careDays: 0,
                     lastCareTime: null,
+                    trait: pickAnimalTraitKey(type) || 'steadfast',
+                    butcherableOnDay: newDay + ANIMAL_MIN_BUTCHER_AGE_DAYS,
                   });
                   availableSlots -= 1;
                 }
@@ -1731,6 +1744,11 @@ const FarmGame = () => {
             stateRef.current.animals = nextAnimals;
             return nextAnimals;
           });
+
+          if (newbornAnimals.length > 0) {
+            const firstNewborn = newbornAnimals[0];
+            promptAnimalNaming(firstNewborn.id, firstNewborn.name || '');
+          }
 
           if (Object.keys(producedGoods).length > 0) {
             const produceSummary = Object.entries(producedGoods).map(([productKey, amount]) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -508,6 +508,7 @@ const FarmGame = () => {
   const [inventorySortMode, setInventorySortMode] = useState('value');
 
   const stateRef = useRef({});
+  const newbornAnimalsRef = useRef([]);
 
   const notificationCenter = useMemo(() => new NotificationCenter(setNotifications), []);
   const addNotification = useCallback((message, options) => {
@@ -1374,9 +1375,11 @@ const FarmGame = () => {
 
           // 動物每日狀態與收入結算
           const producedGoods = {};
-          let newbornAnimalsCaptured = [];
+          newbornAnimalsRef.current = [];
           setAnimals(prevAnimals => {
+            const localNewborns = [];
             if (!Array.isArray(prevAnimals) || prevAnimals.length === 0) {
+              newbornAnimalsRef.current = localNewborns;
               return prevAnimals;
             }
 
@@ -1388,7 +1391,6 @@ const FarmGame = () => {
             const sickAnimals = [];
             const outbreakVictims = [];
             const overcrowdAlerts = [];
-            const newbornAnimals = [];
             const careReminders = [];
             const careWarnings = [];
             const dirtyPens = [];
@@ -1656,8 +1658,8 @@ const FarmGame = () => {
                   typeCounts[type] = (typeCounts[type] || 0) + 1;
                   const babyIndex = typeCounts[type];
                   const babyName = `${data.name}寶寶${babyIndex}`;
-                  newbornAnimals.push({
-                    id: Date.now() + newbornAnimals.length + Math.floor(Math.random() * 1000),
+                  localNewborns.push({
+                    id: Date.now() + localNewborns.length + Math.floor(Math.random() * 1000),
                     type,
                     happiness: data.happiness,
                     hunger: 68,
@@ -1739,17 +1741,18 @@ const FarmGame = () => {
               addNotification(`🧹 ${regularDirty.join('、')} 的欄舍需要整理，保持清潔讓牠們更安心。`, { type: 'warning' });
             }
 
-            if (newbornAnimals.length > 0) {
-              const names = newbornAnimals.map(animal => animal.name).join('、');
+            if (localNewborns.length > 0) {
+              const names = localNewborns.map(animal => animal.name).join('、');
               addNotification(`🐣 ${names} 出生了，農場又更熱鬧了！`, { type: 'success' });
             }
 
-            const nextAnimals = [...processedAnimals, ...newbornAnimals];
+            const nextAnimals = [...processedAnimals, ...localNewborns];
             stateRef.current.animals = nextAnimals;
-            newbornAnimalsCaptured = newbornAnimals;
+            newbornAnimalsRef.current = localNewborns;
             return nextAnimals;
           });
 
+          const newbornAnimalsCaptured = newbornAnimalsRef.current;
           if (newbornAnimalsCaptured.length > 0) {
             const firstNewborn = newbornAnimalsCaptured[0];
             promptAnimalNaming(firstNewborn.id, firstNewborn.name || '');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1418,6 +1418,7 @@ const FarmGame = () => {
               const previousHunger = animal.hunger ?? 60;
               const hungerLoss = ANIMAL_ECOLOGY_CONFIG.dailyHungerLoss * hungerLossFactor;
               const hunger = Math.max(0, previousHunger - hungerLoss);
+              const nextAge = Math.max(0, Math.floor((animal.age ?? 0) + 1));
 
               if (hunger <= 0) {
                 starvationLosses.push(animal.name);
@@ -1572,6 +1573,7 @@ const FarmGame = () => {
                 cleanliness: Math.max(0, Math.min(100, cleanliness)),
                 careNeed: careNeed || null,
                 careDays: careNeed ? careDays : 0,
+                age: nextAge,
               });
               return list;
             }, []);
@@ -1669,6 +1671,7 @@ const FarmGame = () => {
                     careDays: 0,
                     lastCareTime: null,
                     trait: pickAnimalTraitKey(type) || 'steadfast',
+                    age: 0,
                     butcherableOnDay: newDay + ANIMAL_MIN_BUTCHER_AGE_DAYS,
                   });
                   availableSlots -= 1;
@@ -2461,6 +2464,7 @@ const FarmGame = () => {
                     const careMeta = careNeed ? ANIMAL_CARE_ACTIONS[careNeed] : null;
                     const careDays = Math.max(0, animal.careDays ?? 0);
                     const careUrgent = careDays >= 3;
+                    const ageYears = Math.max(0, Math.floor(animal.age ?? 0));
                     const traitInfo = animal.trait && ANIMAL_TRAIT_MAP[animal.trait]
                       ? ANIMAL_TRAIT_MAP[animal.trait]
                       : ANIMAL_TRAIT_MAP.steadfast;
@@ -2529,6 +2533,10 @@ const FarmGame = () => {
                                 </button>
                               </div>
                             )}
+                            <div className="flex items-center justify-center gap-1 text-[11px] text-slate-600">
+                              <Clock3 className="w-3 h-3" />
+                              <span>年齡 {ageYears} 歲</span>
+                            </div>
                             {traitInfo && (
                               <div
                                 className="flex items-center justify-center gap-1 text-[11px] text-amber-700"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1374,6 +1374,7 @@ const FarmGame = () => {
 
           // 動物每日狀態與收入結算
           const producedGoods = {};
+          let newbornAnimalsCaptured = [];
           setAnimals(prevAnimals => {
             if (!Array.isArray(prevAnimals) || prevAnimals.length === 0) {
               return prevAnimals;
@@ -1745,11 +1746,12 @@ const FarmGame = () => {
 
             const nextAnimals = [...processedAnimals, ...newbornAnimals];
             stateRef.current.animals = nextAnimals;
+            newbornAnimalsCaptured = newbornAnimals;
             return nextAnimals;
           });
 
-          if (newbornAnimals.length > 0) {
-            const firstNewborn = newbornAnimals[0];
+          if (newbornAnimalsCaptured.length > 0) {
+            const firstNewborn = newbornAnimalsCaptured[0];
             promptAnimalNaming(firstNewborn.id, firstNewborn.name || '');
           }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,19 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed, TrendingUp, TrendingDown, Clock3, Boxes, Sparkles } from 'lucide-react';
 import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from './game/data/GameCatalog';
 import { GameFormatter } from './game/utils/GameFormatter';
-import { GameEngine, getFarmExpansionCost, getAnimalHousingExpansionCost, BASE_FARM_PLOTS, MAX_FARM_PLOTS, BASE_ANIMAL_CAPACITY, MAX_ANIMAL_CAPACITY, FARM_EXPANSION_BATCH, ANIMAL_CAPACITY_STEP, BUILDING_UPGRADES, ANIMAL_CARE_ACTIONS } from './game/engine/GameEngine';
+import { GameEngine } from './game/engine/GameEngine';
+import {
+  getFarmExpansionCost,
+  getAnimalHousingExpansionCost,
+  BASE_FARM_PLOTS,
+  MAX_FARM_PLOTS,
+  BASE_ANIMAL_CAPACITY,
+  MAX_ANIMAL_CAPACITY,
+  FARM_EXPANSION_BATCH,
+  ANIMAL_CAPACITY_STEP,
+  BUILDING_UPGRADES,
+  ANIMAL_CARE_ACTIONS,
+} from './game/engine/constants';
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
 import { createInitialInventory, INVENTORY_METADATA, INVENTORY_ORDER } from './game/state/InventoryState';

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1675,7 +1675,7 @@ const FarmGame = () => {
                     lastCareTime: null,
                     trait: pickAnimalTraitKey(type) || 'steadfast',
                     age: 0,
-                    butcherableOnDay: newDay + ANIMAL_MIN_BUTCHER_AGE_DAYS,
+                    butcherableOnDay: upcomingDay + ANIMAL_MIN_BUTCHER_AGE_DAYS,
                   });
                   availableSlots -= 1;
                 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,10 @@ import {
   ANIMAL_TRAIT_MAP,
   ANIMAL_MIN_BUTCHER_AGE_DAYS,
   pickAnimalTraitKey,
+  getEnergyCapacity,
+  getRestRecoveryAmount,
+  ENERGY_RESTS_PER_DAY,
+  ENERGY_DRINK_RECOVERY,
 } from './game/engine/constants';
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
@@ -443,6 +447,7 @@ const FarmGame = () => {
   // 基本狀態
   const [money, setMoney] = useState(500);
   const [energy, setEnergy] = useState(100);
+  const [restCharges, setRestCharges] = useState(ENERGY_RESTS_PER_DAY);
   const [level, setLevel] = useState(1);
   const [experience, setExperience] = useState(0);
   const [time, setTime] = useState(6);
@@ -472,6 +477,7 @@ const FarmGame = () => {
     fertilizer: 0,
     pesticide: 0,
     medicine: 0,
+    energyDrink: 0,
   });
 
   const [questLog, setQuestLog] = useState({});
@@ -838,6 +844,19 @@ const FarmGame = () => {
       energyReduction,
     };
   }, [tools, toolLevels]);
+
+  const energyCap = useMemo(
+    () => getEnergyCapacity(level, buildings),
+    [level, buildings],
+  );
+  const restRecovery = useMemo(
+    () => getRestRecoveryAmount(level, buildings),
+    [level, buildings],
+  );
+  const energyDrinkCount = farmSupplies?.energyDrink || 0;
+  const canRest = restCharges > 0 && energy < energyCap;
+  const canUseEnergyDrink = energyDrinkCount > 0 && energy < energyCap;
+  const drinkRecoveryPreview = Math.min(ENERGY_DRINK_RECOVERY, Math.max(0, energyCap - energy));
   
   // 存檔狀態
   const [saveSlots, setSaveSlots] = useState({
@@ -853,6 +872,8 @@ const FarmGame = () => {
   stateRef.current = {
     money,
     energy,
+    energyCap,
+    restCharges,
     level,
     experience,
     time,
@@ -895,6 +916,16 @@ const FarmGame = () => {
     dynamicQuests,
   };
 
+  useEffect(() => {
+    if (energy > energyCap) {
+      setEnergy(prev => {
+        const next = Math.min(energyCap, prev);
+        stateRef.current.energy = next;
+        return next;
+      });
+    }
+  }, [energy, energyCap, setEnergy]);
+
   const saveManager = useMemo(() => new SaveManager({
     stateRef,
     setters: {
@@ -911,6 +942,7 @@ const FarmGame = () => {
       setFarm,
       setAnimals,
       setAnimalCapacity,
+      setRestCharges,
       setBuildings,
       setTools,
       setOwnedTools,
@@ -1259,7 +1291,13 @@ const FarmGame = () => {
       const advices = [
         weather === 'sunny' ? '☀️ 晴天適合種植番茄和草莓！' : '',
         weather === 'rainy' ? '🌧️ 雨天作物會自動澆水，適合種植小麥！' : '',
-        energy < 30 ? '⚡ 體力不足，建議休息或升級工具！' : '',
+        energy < Math.min(30, Math.floor(energyCap * 0.35)) ? '⚡ 體力不足，記得休息或升級工具！' : '',
+        restCharges > 0 && energy < energyCap && (energyCap - energy) >= Math.max(10, Math.floor(restRecovery * 0.75))
+          ? `🛏️ 還有 ${restCharges} 次小憩機會，稍作休息可恢復體力！`
+          : '',
+        (farmSupplies?.energyDrink || 0) > 0 && energy < energyCap && (energyCap - energy) >= ENERGY_DRINK_RECOVERY / 2
+          ? '🥤 倉庫有精力飲料，緊湊行程時別忘了補充！'
+          : '',
         money > 2000 ? '💰 資金充足，考慮建造新建築！' : '',
         safeAnimals.some(a => (a.happiness ?? 50) < 40) ? '🐾 有動物心情低落，餵食或陪伴牠們吧！' : '',
         safeAnimals.some(a => (a.hunger ?? 60) < 35) ? '🍽️ 有動物快餓扁了，趕快餵牠們！' : '',
@@ -1279,7 +1317,7 @@ const FarmGame = () => {
     const timer = setInterval(generateAdvice, 60000);
     generateAdvice();
     return () => clearInterval(timer);
-  }, [weather, energy, money, animals, inventory, farm]);
+  }, [weather, energy, energyCap, restCharges, restRecovery, money, animals, inventory, farmSupplies, farm]);
 
   // 動態市場價格
   useEffect(() => {
@@ -1371,7 +1409,17 @@ const FarmGame = () => {
           }
 
           handleDailyEvents(upcomingDay, nextSeasonValue, currentWeather);
-          setEnergy(100);
+          const currentLevel = stateRef.current.level || level;
+          const currentBuildings = stateRef.current.buildings || buildings;
+          const nextEnergyCap = getEnergyCapacity(currentLevel, currentBuildings);
+          setEnergy(() => {
+            stateRef.current.energy = nextEnergyCap;
+            return nextEnergyCap;
+          });
+          setRestCharges(() => {
+            stateRef.current.restCharges = ENERGY_RESTS_PER_DAY;
+            return ENERGY_RESTS_PER_DAY;
+          });
 
           // 動物每日狀態與收入結算
           const producedGoods = {};
@@ -2082,9 +2130,41 @@ const FarmGame = () => {
     gameEngine.buySupply(supplyType, { quantity });
   }, [gameEngine]);
 
-  const selectSupply = useCallback((supplyType) => {
-    gameEngine.selectSupply(supplyType);
+  const consumeEnergyDrink = useCallback(() => {
+    gameEngine.drinkEnergySupply();
   }, [gameEngine]);
+
+  const selectSupply = useCallback((supplyType) => {
+    if (supplyType === 'energyDrink') {
+      consumeEnergyDrink();
+      return;
+    }
+    gameEngine.selectSupply(supplyType);
+  }, [gameEngine, consumeEnergyDrink]);
+
+  const restAtHome = useCallback(() => {
+    if (energy >= energyCap) {
+      addNotification('體力已經滿滿的囉！', { type: 'info' });
+      return;
+    }
+    if (restCharges <= 0) {
+      addNotification('今天的休息次數已用完，試著喝瓶精力飲料吧！', { type: 'warning' });
+      return;
+    }
+
+    const recoverable = Math.min(restRecovery, energyCap - energy);
+    setEnergy(prev => {
+      const next = Math.min(energyCap, prev + recoverable);
+      stateRef.current.energy = next;
+      return next;
+    });
+    setRestCharges(prev => {
+      const next = Math.max(0, prev - 1);
+      stateRef.current.restCharges = next;
+      return next;
+    });
+    addNotification(`小憩片刻，恢復 ${recoverable} 體力！`, { type: 'success' });
+  }, [energy, energyCap, restCharges, restRecovery, setEnergy, setRestCharges, addNotification]);
 
   const applySupply = useCallback((plotId) => gameEngine.applySupply(plotId), [gameEngine]);
 
@@ -2224,9 +2304,33 @@ const FarmGame = () => {
             <Coins className="w-5 h-5 text-yellow-400" />
             <span className="font-bold">${money}</span>
           </div>
-          <div className="flex items-center space-x-1">
-            <Zap className="w-5 h-5 text-blue-400" />
-            <span>{energy}/100</span>
+          <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-1">
+              <Zap className="w-5 h-5 text-blue-200" />
+              <span>{Math.round(energy)}/{energyCap}</span>
+            </div>
+            <button
+              onClick={restAtHome}
+              disabled={!canRest}
+              className={`text-xs px-2 py-[2px] rounded-full border transition-colors ${
+                canRest
+                  ? 'bg-white/20 hover:bg-white/30 border-white/50 text-white'
+                  : 'bg-white/5 border-white/20 text-white/50 cursor-not-allowed'
+              }`}
+            >
+              小憩 +{Math.round(restRecovery)}
+            </button>
+            <button
+              onClick={consumeEnergyDrink}
+              disabled={!canUseEnergyDrink}
+              className={`text-xs px-2 py-[2px] rounded-full border transition-colors ${
+                canUseEnergyDrink
+                  ? 'bg-pink-500/30 hover:bg-pink-500/40 border-pink-200 text-white'
+                  : 'bg-white/5 border-white/20 text-white/50 cursor-not-allowed'
+              }`}
+            >
+              精力 +{Math.round(drinkRecoveryPreview)} ({energyDrinkCount})
+            </button>
           </div>
           <div className="flex items-center space-x-1">
             <Star className="w-5 h-5 text-yellow-400" />
@@ -2381,6 +2485,17 @@ const FarmGame = () => {
                   </div>
                 );
               })}
+            </div>
+            <div className="mb-4 flex flex-wrap items-center gap-2 text-xs">
+              <span className="px-2 py-1 rounded-full bg-blue-100/80 text-blue-800 border border-blue-200/70">
+                體力上限 {energyCap}
+              </span>
+              <span className="px-2 py-1 rounded-full bg-sky-100/80 text-sky-800 border border-sky-200/70">
+                今日小憩剩餘 {restCharges} 次
+              </span>
+              <span className="px-2 py-1 rounded-full bg-pink-100/80 text-pink-800 border border-pink-200/70">
+                精力飲料庫存 {energyDrinkCount}
+              </span>
             </div>
             {sprinklerLevel > 0 && (
               <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-700 flex items-center gap-2">
@@ -3494,7 +3609,9 @@ const FarmGame = () => {
               <section>
                 <h3 className="font-semibold text-lg text-sky-600">⚡ 體力、天氣與季節</h3>
                 <ul className="list-disc pl-5 space-y-1 mt-2">
-                  <li>每日體力上限 100，種植、澆水等行動會消耗體力。</li>
+                  <li>體力上限會隨等級與部分建築提升，升級工具則能降低消耗。</li>
+                  <li>每天清晨會回滿體力並重置 {ENERGY_RESTS_PER_DAY} 次「小憩」，每次大約恢復四分之一體力。</li>
+                  <li>精力飲料可立即補充大量體力，記得在農務用品保持庫存。</li>
                   <li>雨天會自動澆水，晴天適合日照作物，雪天則要小心成長變慢。</li>
                   <li>每 30 天進入新季節（春→夏→秋→冬），部分作物或動物在特定季節表現更好。</li>
                 </ul>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -525,6 +525,23 @@ const FarmGame = () => {
     [questManager, dynamicQuests],
   );
 
+  // 新功能狀態
+  const [completedAchievements, setCompletedAchievements] = useState(new Set());
+  const [aiAdvice, setAiAdvice] = useState('');
+  const [marketPrices, setMarketPrices] = useState({});
+  const [previousMarketPrices, setPreviousMarketPrices] = useState({});
+  const [marketUpdateTime, setMarketUpdateTime] = useState(null);
+  const [dailyStats, setDailyStats] = useState([]);
+  const [lifetimeStats, setLifetimeStats] = useState({ cropsPlanted: 0 });
+  const [automation, setAutomation] = useState({ autoWater: false, autoHarvest: false });
+  const [seasonalEvents, setSeasonalEvents] = useState([]);
+  const [seasonalEventHistory, setSeasonalEventHistory] = useState({});
+  const [weatherMissions, setWeatherMissions] = useState([]);
+  const [weatherMissionHistory, setWeatherMissionHistory] = useState({});
+  const [marketCommissions, setMarketCommissions] = useState([]);
+  const [commissionHistory, setCommissionHistory] = useState({});
+  const [marketBoosts, setMarketBoosts] = useState({});
+
   const handleDailyEvents = useCallback((newDay, effectiveSeason, currentWeather) => {
     const dayInSeason = ((newDay - 1) % 30) + 1;
 
@@ -725,23 +742,6 @@ const FarmGame = () => {
     };
   }, [tools, toolLevels]);
   
-  // 新功能狀態
-  const [completedAchievements, setCompletedAchievements] = useState(new Set());
-  const [aiAdvice, setAiAdvice] = useState('');
-  const [marketPrices, setMarketPrices] = useState({});
-  const [previousMarketPrices, setPreviousMarketPrices] = useState({});
-  const [marketUpdateTime, setMarketUpdateTime] = useState(null);
-  const [dailyStats, setDailyStats] = useState([]);
-  const [lifetimeStats, setLifetimeStats] = useState({ cropsPlanted: 0 });
-  const [automation, setAutomation] = useState({ autoWater: false, autoHarvest: false });
-  const [seasonalEvents, setSeasonalEvents] = useState([]);
-  const [seasonalEventHistory, setSeasonalEventHistory] = useState({});
-  const [weatherMissions, setWeatherMissions] = useState([]);
-  const [weatherMissionHistory, setWeatherMissionHistory] = useState({});
-  const [marketCommissions, setMarketCommissions] = useState([]);
-  const [commissionHistory, setCommissionHistory] = useState({});
-  const [marketBoosts, setMarketBoosts] = useState({});
-
   // 存檔狀態
   const [saveSlots, setSaveSlots] = useState({
     slot1: null,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed, TrendingUp, TrendingDown, Clock3, Boxes, Sparkles } from 'lucide-react';
+import { Sprout, Coins, ShoppingCart, Heart, Home, Sun, Moon, Zap, Droplets, Hammer, Building, Star, Save, Trophy, Settings, MessageCircle, Target, UtensilsCrossed, TrendingUp, TrendingDown, Clock3, Boxes, Sparkles, Pencil, Check, X, Gem } from 'lucide-react';
 import { CROPS, ANIMALS, BUILDINGS, TOOLS, ACHIEVEMENTS, NPCS, WEATHER_TYPES, SEASONS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from './game/data/GameCatalog';
 import { GameFormatter } from './game/utils/GameFormatter';
 import { GameEngine } from './game/engine/GameEngine';
@@ -14,6 +14,8 @@ import {
   ANIMAL_CAPACITY_STEP,
   BUILDING_UPGRADES,
   ANIMAL_CARE_ACTIONS,
+  ANIMAL_TRAITS,
+  ANIMAL_TRAIT_MAP,
 } from './game/engine/constants';
 import { SaveManager } from './game/engine/SaveManager';
 import { NotificationCenter } from './game/engine/NotificationCenter';
@@ -475,6 +477,8 @@ const FarmGame = () => {
 
   const [animals, setAnimals] = useState([]);
   const [animalCapacity, setAnimalCapacity] = useState(BASE_ANIMAL_CAPACITY);
+  const [renamingAnimalId, setRenamingAnimalId] = useState(null);
+  const [pendingAnimalName, setPendingAnimalName] = useState('');
   const [buildings, setBuildings] = useState({});
   const [tools, setTools] = useState('basic');
   const [ownedTools, setOwnedTools] = useState(() => ['basic']);
@@ -510,6 +514,88 @@ const FarmGame = () => {
   const dismissNotification = useCallback((id) => {
     notificationCenter.dismiss(id);
   }, [notificationCenter]);
+
+  const startAnimalRename = useCallback((animal) => {
+    if (!animal) {
+      return;
+    }
+    setRenamingAnimalId(animal.id);
+    setPendingAnimalName(animal.name || '');
+  }, []);
+
+  const cancelAnimalRename = useCallback(() => {
+    setRenamingAnimalId(null);
+    setPendingAnimalName('');
+  }, []);
+
+  const commitAnimalRename = useCallback(() => {
+    if (!renamingAnimalId) {
+      return;
+    }
+
+    let finalizedName = null;
+    setAnimals(prevAnimals => {
+      if (!Array.isArray(prevAnimals) || prevAnimals.length === 0) {
+        return prevAnimals;
+      }
+
+      const targetIndex = prevAnimals.findIndex(entry => entry.id === renamingAnimalId);
+      if (targetIndex === -1) {
+        return prevAnimals;
+      }
+
+      const targetAnimal = prevAnimals[targetIndex];
+      const sanitizedInput = pendingAnimalName.replace(/\s+/g, ' ').trim().slice(0, 20);
+      const others = prevAnimals.filter(entry => entry.id !== renamingAnimalId);
+      const usedNames = new Set(others.map(entry => entry.name).filter(Boolean));
+      const baseLabel = ANIMALS[targetAnimal.type]?.name || '動物';
+      let candidate = sanitizedInput;
+
+      if (!candidate) {
+        let suffix = 1;
+        candidate = `${baseLabel}${suffix}`;
+        while (usedNames.has(candidate)) {
+          suffix += 1;
+          candidate = `${baseLabel}${suffix}`;
+        }
+      } else if (usedNames.has(candidate)) {
+        let suffix = 2;
+        while (usedNames.has(`${candidate} (${suffix})`)) {
+          suffix += 1;
+        }
+        candidate = `${candidate} (${suffix})`;
+      }
+
+      finalizedName = candidate;
+      const nextAnimals = prevAnimals.map(entry => (
+        entry.id === renamingAnimalId
+          ? { ...entry, name: candidate }
+          : entry
+      ));
+      stateRef.current.animals = nextAnimals;
+      return nextAnimals;
+    });
+
+    if (finalizedName) {
+      addNotification(`🐾 ${finalizedName} 很喜歡這個名字！`, { type: 'success' });
+    }
+    setRenamingAnimalId(null);
+    setPendingAnimalName('');
+  }, [renamingAnimalId, pendingAnimalName, setAnimals, addNotification]);
+
+  const handleAnimalRenameChange = useCallback((event) => {
+    setPendingAnimalName(event.target.value);
+  }, []);
+
+  const handleAnimalRenameKeyDown = useCallback((event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitAnimalRename();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelAnimalRename();
+    }
+  }, [commitAnimalRename, cancelAnimalRename]);
 
   const questManager = useMemo(() => new QuestManager({
     stateRef,
@@ -1308,9 +1394,19 @@ const FarmGame = () => {
               const animalData = ANIMALS[animal.type];
               const shelterKey = animalData.shelter;
               const boost = gameEngine.getShelterBoost(buildings, shelterKey);
+              const traitMeta = animal.trait ? ANIMAL_TRAIT_MAP[animal.trait] : null;
+              const traitModifiers = traitMeta?.modifiers || {};
+              const hungerLossFactor = traitModifiers.hungerLoss ?? 1;
+              const happinessDecayFactor = traitModifiers.happinessDecay ?? 1;
+              const bondDecayFactor = traitModifiers.bondDecay ?? 1;
+              const cleanlinessDecayFactor = traitModifiers.cleanlinessDecay ?? 1;
+              const sicknessRiskFactor = traitModifiers.sicknessRisk ?? 1;
+              const productionFactor = traitModifiers.production ?? 1;
+              const hungerMoodPenaltyFactor = traitModifiers.hungerMoodPenalty ?? 1;
 
               const previousHunger = animal.hunger ?? 60;
-              const hunger = Math.max(0, previousHunger - ANIMAL_ECOLOGY_CONFIG.dailyHungerLoss);
+              const hungerLoss = ANIMAL_ECOLOGY_CONFIG.dailyHungerLoss * hungerLossFactor;
+              const hunger = Math.max(0, previousHunger - hungerLoss);
 
               if (hunger <= 0) {
                 starvationLosses.push(animal.name);
@@ -1318,15 +1414,16 @@ const FarmGame = () => {
               }
 
               const baseHappiness = animal.happiness ?? animalData.happiness;
-              let happiness = Math.max(0, baseHappiness - ANIMAL_ECOLOGY_CONFIG.happinessDecay);
+              const happinessDecay = ANIMAL_ECOLOGY_CONFIG.happinessDecay * happinessDecayFactor;
+              let happiness = Math.max(0, baseHappiness - happinessDecay);
               let sick = Boolean(animal.sick);
               const wasSick = Boolean(animal.sick);
               let sicknessDays = animal.sicknessDays ?? (wasSick ? 1 : 0);
 
               let bond = Math.max(0, animal.bond ?? 0);
-              bond = Math.max(0, Math.min(100, bond - ANIMAL_INTERACTION_CONFIG.bondDecay));
+              bond = Math.max(0, Math.min(100, bond - (ANIMAL_INTERACTION_CONFIG.bondDecay * bondDecayFactor)));
               let cleanliness = Math.max(0, animal.cleanliness ?? 80);
-              cleanliness = Math.max(0, Math.min(100, cleanliness - ANIMAL_INTERACTION_CONFIG.cleanlinessDecay));
+              cleanliness = Math.max(0, Math.min(100, cleanliness - (ANIMAL_INTERACTION_CONFIG.cleanlinessDecay * cleanlinessDecayFactor)));
 
               let careNeed = animal.careNeed && ANIMAL_CARE_ACTIONS[animal.careNeed] ? animal.careNeed : null;
               let careDays = Math.max(0, animal.careDays ?? 0);
@@ -1365,7 +1462,7 @@ const FarmGame = () => {
                     if (careDays >= 3) {
                       careWarnings.push(`${animal.name}（${meta.shortLabel}）`);
                     }
-                    const sicknessChance = ANIMAL_INTERACTION_CONFIG.neglectSicknessChance * Math.max(1, careDays - 1);
+                    const sicknessChance = ANIMAL_INTERACTION_CONFIG.neglectSicknessChance * Math.max(1, careDays - 1) * sicknessRiskFactor;
                     if (!sick && Math.random() < sicknessChance) {
                       sick = true;
                       newlySick.push(animal.name);
@@ -1380,17 +1477,20 @@ const FarmGame = () => {
 
               if (hunger <= ANIMAL_ECOLOGY_CONFIG.severeHungerThreshold) {
                 hungryNames.push(`${animal.name}（急需餵食）`);
-                happiness = Math.max(0, happiness - ANIMAL_ECOLOGY_CONFIG.severeHungerPenalty);
+                happiness = Math.max(0, happiness - (ANIMAL_ECOLOGY_CONFIG.severeHungerPenalty * hungerMoodPenaltyFactor));
                 canProduce = false;
               } else if (hunger <= ANIMAL_ECOLOGY_CONFIG.hungerWarningThreshold) {
                 hungryNames.push(animal.name);
-                happiness = Math.max(0, happiness - ANIMAL_ECOLOGY_CONFIG.moderateHungerPenalty);
+                happiness = Math.max(0, happiness - (ANIMAL_ECOLOGY_CONFIG.moderateHungerPenalty * hungerMoodPenaltyFactor));
                 canProduce = happiness > 30;
               }
 
               if (!sick && (hunger <= ANIMAL_ECOLOGY_CONFIG.sicknessTriggerThreshold || happiness <= ANIMAL_ECOLOGY_CONFIG.sicknessTriggerThreshold)) {
-                sick = true;
-                newlySick.push(animal.name);
+                const triggerChance = Math.min(1, Math.max(0, sicknessRiskFactor));
+                if (Math.random() < triggerChance) {
+                  sick = true;
+                  newlySick.push(animal.name);
+                }
               }
 
               if (cleanliness < ANIMAL_INTERACTION_CONFIG.cleanlinessThreshold) {
@@ -1401,7 +1501,7 @@ const FarmGame = () => {
                 filthyPens.push(animal.name);
                 happiness = Math.max(0, happiness - ANIMAL_INTERACTION_CONFIG.severeCleanlinessPenalty);
                 bond = Math.max(0, bond - 1);
-                if (!sick && Math.random() < ANIMAL_INTERACTION_CONFIG.cleanlinessSicknessChance) {
+                if (!sick && Math.random() < ANIMAL_INTERACTION_CONFIG.cleanlinessSicknessChance * sicknessRiskFactor) {
                   sick = true;
                   newlySick.push(animal.name);
                 }
@@ -1427,11 +1527,11 @@ const FarmGame = () => {
                 if (animalData.product && ANIMAL_PRODUCTS[animalData.product]) {
                   const productKey = animalData.product;
                   const baseUnits = 1;
-                  const units = Math.max(1, Math.round(baseUnits * boost * (happiness / 100)));
+                  const units = Math.max(1, Math.round(baseUnits * boost * (happiness / 100) * productionFactor));
                   productReady += units;
                   producedGoods[productKey] = (producedGoods[productKey] || 0) + units;
                 } else {
-                  income = Math.floor((animalData.income || 0) * boost * (happiness / 100));
+                  income = Math.floor((animalData.income || 0) * boost * (happiness / 100) * productionFactor);
                 }
               }
               totalIncome += income;
@@ -2343,6 +2443,9 @@ const FarmGame = () => {
                     const careMeta = careNeed ? ANIMAL_CARE_ACTIONS[careNeed] : null;
                     const careDays = Math.max(0, animal.careDays ?? 0);
                     const careUrgent = careDays >= 3;
+                    const traitInfo = animal.trait && ANIMAL_TRAIT_MAP[animal.trait]
+                      ? ANIMAL_TRAIT_MAP[animal.trait]
+                      : ANIMAL_TRAIT_MAP.steadfast;
                     return (
                       <div key={animal.id}
                            className={`rounded-lg p-3 transition-colors relative border ${
@@ -2367,7 +2470,57 @@ const FarmGame = () => {
                           <div className="text-3xl animate-bounce">
                             {animalData.emoji}
                           </div>
-                          <div className="text-sm font-semibold">{animal.name}</div>
+                          <div className="space-y-1">
+                            {renamingAnimalId === animal.id ? (
+                              <div className="flex items-center justify-center gap-1">
+                                <input
+                                  value={pendingAnimalName}
+                                  onChange={handleAnimalRenameChange}
+                                  onKeyDown={handleAnimalRenameKeyDown}
+                                  className="w-24 rounded border border-blue-200 px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-400"
+                                  maxLength={24}
+                                  autoFocus
+                                />
+                                <button
+                                  type="button"
+                                  onClick={commitAnimalRename}
+                                  className="p-1 rounded bg-green-500 hover:bg-green-600 text-white"
+                                  aria-label="儲存動物名稱"
+                                >
+                                  <Check className="w-3 h-3" />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={cancelAnimalRename}
+                                  className="p-1 rounded bg-gray-200 hover:bg-gray-300 text-gray-700"
+                                  aria-label="取消重新命名"
+                                >
+                                  <X className="w-3 h-3" />
+                                </button>
+                              </div>
+                            ) : (
+                              <div className="flex items-center justify-center gap-2">
+                                <span className="text-sm font-semibold">{animal.name}</span>
+                                <button
+                                  type="button"
+                                  onClick={() => startAnimalRename(animal)}
+                                  className="text-xs text-blue-600 hover:text-blue-800"
+                                  aria-label="重新命名動物"
+                                >
+                                  <Pencil className="w-3 h-3" />
+                                </button>
+                              </div>
+                            )}
+                            {traitInfo && (
+                              <div
+                                className="flex items-center justify-center gap-1 text-[11px] text-amber-700"
+                                title={traitInfo.description}
+                              >
+                                <Gem className="w-3 h-3" />
+                                <span>{traitInfo.name}</span>
+                              </div>
+                            )}
+                          </div>
                           <div className="space-y-1 text-xs">
                             <div className="flex items-center justify-center gap-1">
                               <Heart className="w-3 h-3 text-red-400" />
@@ -3287,6 +3440,17 @@ const FarmGame = () => {
                   <li>每天餵食會扣飼料費，但能維持快樂度（最高 100）。</li>
                   <li>快樂度越高，產出的金幣越多；建築會提供額外加成。</li>
                   <li>動物長期飢餓或心情低落會生病，產出停擺，記得準備營養劑治療。</li>
+                </ul>
+              </section>
+              <section>
+                <h3 className="font-semibold text-lg text-pink-600">🧬 動物特質</h3>
+                <p className="mt-2">每隻動物現在都會擁有隨機特質，會影響飢餓速度、生病風險或產量表現。試著照顧牠們的性格，善用優勢、彌補弱點！</p>
+                <ul className="list-disc pl-5 space-y-1 mt-2">
+                  {ANIMAL_TRAITS.map(trait => (
+                    <li key={trait.key}>
+                      <span className="font-semibold text-rose-500">{trait.name}</span>：{trait.description}
+                    </li>
+                  ))}
                 </ul>
               </section>
               <section>

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -300,6 +300,12 @@ class GameCatalog {
         emoji: '💊',
         description: '治療生病的動物並恢復部分快樂度。',
       }),
+      energyDrink: new Supply('energyDrink', {
+        name: '精力飲料',
+        price: 65,
+        emoji: '🥤',
+        description: '立即恢復大量體力，適合忙碌的一天。',
+      }),
     };
 
     this.tools = {

--- a/src/game/data/GameCatalog.js
+++ b/src/game/data/GameCatalog.js
@@ -334,6 +334,9 @@ class GameCatalog {
 
     this.achievements = [
       new Achievement({ id: 'firstPlant', name: '初次種植', description: '種下第一株作物', reward: 100, icon: '🌱' }),
+      new Achievement({ id: 'planter100', name: '新銳栽培家', description: '累計種植100株作物', reward: 250, icon: '🌿' }),
+      new Achievement({ id: 'planter500', name: '資深栽培家', description: '累計種植500株作物', reward: 600, icon: '🪴' }),
+      new Achievement({ id: 'planter1000', name: '傳奇栽培家', description: '累計種植1000株作物', reward: 1200, icon: '🌳' }),
       new Achievement({ id: 'richFarmer', name: '富豪農夫', description: '擁有10000金幣', reward: 500, icon: '💰' }),
       new Achievement({ id: 'animalLover', name: '動物愛好者', description: '擁有10隻動物', reward: 300, icon: '🐾' }),
       new Achievement({ id: 'builder', name: '建築大師', description: '建造5個建築', reward: 800, icon: '🏗️' }),

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -12,19 +12,6 @@ import {
   MAX_FARM_PLOTS,
 } from './constants';
 
-export {
-  ANIMAL_CARE_ACTIONS,
-  ANIMAL_CAPACITY_STEP,
-  BASE_ANIMAL_CAPACITY,
-  BASE_FARM_PLOTS,
-  BUILDING_UPGRADES,
-  FARM_EXPANSION_BATCH,
-  getAnimalHousingExpansionCost,
-  getFarmExpansionCost,
-  MAX_ANIMAL_CAPACITY,
-  MAX_FARM_PLOTS,
-} from './constants';
-
 export class GameEngine {
   constructor({ stateRef, setters, notifier }) {
     this.stateRef = stateRef;

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -580,7 +580,7 @@ export class GameEngine {
   }
 
   plantSeed(plotId) {
-    const { selectedSeed, tools, energy, money, inventory, season, farm } = this.state;
+    const { selectedSeed, tools, energy, money, inventory, season, farm, lifetimeStats } = this.state;
     if (!selectedSeed) return;
 
     const farmList = Array.isArray(farm) ? farm : [];
@@ -627,6 +627,19 @@ export class GameEngine {
       this.stateRef.current.farm = nextFarm;
       return nextFarm;
     });
+
+    if (typeof this.setters.setLifetimeStats === 'function') {
+      const previousStats = lifetimeStats && typeof lifetimeStats === 'object' ? lifetimeStats : {};
+      this.setters.setLifetimeStats(prev => {
+        const base = prev && typeof prev === 'object' ? prev : previousStats;
+        const nextStats = {
+          ...base,
+          cropsPlanted: (base?.cropsPlanted || 0) + 1,
+        };
+        this.stateRef.current.lifetimeStats = nextStats;
+        return nextStats;
+      });
+    }
 
     let remainingSeeds = storedSeeds;
     let remainingMoney = money;

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -1,95 +1,29 @@
 import { CROPS, ANIMALS, BUILDINGS, TOOLS, FARM_SUPPLIES, ANIMAL_PRODUCTS } from '../data/GameCatalog';
+import {
+  ANIMAL_CARE_ACTIONS,
+  ANIMAL_CAPACITY_STEP,
+  BASE_ANIMAL_CAPACITY,
+  BASE_FARM_PLOTS,
+  BUILDING_UPGRADES,
+  FARM_EXPANSION_BATCH,
+  getAnimalHousingExpansionCost,
+  getFarmExpansionCost,
+  MAX_ANIMAL_CAPACITY,
+  MAX_FARM_PLOTS,
+} from './constants';
 
-export const BASE_FARM_PLOTS = 25;
-export const FARM_EXPANSION_BATCH = 1;
-export const MAX_FARM_PLOTS = 45;
-export const BASE_ANIMAL_CAPACITY = 6;
-export const ANIMAL_CAPACITY_STEP = 1;
-export const MAX_ANIMAL_CAPACITY = 24;
-
-export const ANIMAL_CARE_ACTIONS = {
-  playtime: {
-    key: 'playtime',
-    label: '陪牠玩耍',
-    shortLabel: '陪玩',
-    needLabel: '想玩耍',
-    description: '與動物一起玩耍可以大幅提升幸福度與羈絆，但會稍微增加飢餓感。',
-    energyCost: 6,
-    happinessBoost: 18,
-    bondBoost: 14,
-    hungerImpact: 14,
-  },
-  grooming: {
-    key: 'grooming',
-    label: '梳洗打理',
-    shortLabel: '梳洗',
-    needLabel: '想梳洗',
-    description: '細心梳洗讓動物保持乾淨舒適，降低生病風險並增加羈絆。',
-    energyCost: 5,
-    happinessBoost: 12,
-    bondBoost: 10,
-    cleanlinessBoost: 22,
-    sootheSickness: true,
-  },
-  cleanPen: {
-    key: 'cleanPen',
-    label: '清理欄舍',
-    shortLabel: '清理',
-    needLabel: '需要清理',
-    description: '整理環境讓欄舍更乾淨，恢復整潔度並讓動物更安心。',
-    energyCost: 7,
-    happinessBoost: 8,
-    bondBoost: 8,
-    cleanlinessBoost: 28,
-  },
-};
-
-export const getFarmExpansionCost = (currentPlotCount) => {
-  if (currentPlotCount >= MAX_FARM_PLOTS) {
-    return null;
-  }
-  const expansionsPurchased = Math.max(0, currentPlotCount - BASE_FARM_PLOTS);
-  return 1000 + (expansionsPurchased * 250);
-};
-
-export const getAnimalHousingExpansionCost = (currentCapacity) => {
-  if (currentCapacity >= MAX_ANIMAL_CAPACITY) {
-    return null;
-  }
-  return 2500;
-};
-
-export const BUILDING_UPGRADES = {
-  sprinkler: [
-    { level: 1, cost: 650, coverage: 12, manualWaterCost: 3, plantingDiscount: 3, description: '覆蓋 12 格農地，自動補水並減少播種體力。' },
-    { level: 2, cost: 900, coverage: 24, manualWaterCost: 2, plantingDiscount: 4, description: '覆蓋範圍擴大至 24 格，澆水幾乎不費力。' },
-    { level: 3, cost: 1400, coverage: 36, manualWaterCost: 1, plantingDiscount: 5, description: '灌溉到 36 格農地並極大幅度節省體力。' },
-    { level: 4, cost: 2200, coverage: MAX_FARM_PLOTS, manualWaterCost: 1, plantingDiscount: 6, description: '全區自動灌溉，維持土壤最佳濕度。' },
-  ],
-  silo: [
-    { level: 1, cost: 800, sellBonus: 0.05, description: '作物售價 +5%，減少腐壞。' },
-    { level: 2, cost: 1200, sellBonus: 0.1, description: '作物售價 +10%，可長期保存。' },
-    { level: 3, cost: 1800, sellBonus: 0.18, description: '作物售價 +18%，高效率倉儲。' },
-  ],
-  barn: [
-    { level: 1, cost: 1000, boost: 1.2, description: '提供牛羊穩定環境，提升產量。' },
-    { level: 2, cost: 1500, boost: 1.35, description: '擴增飼槽與溫控，提高品質。' },
-    { level: 3, cost: 2200, boost: 1.5, description: '頂級穀倉，讓牛羊更快樂。' },
-  ],
-  chickenCoop: [
-    { level: 1, cost: 500, boost: 1.3, description: '舒適雞舍，提升產蛋率。' },
-    { level: 2, cost: 850, boost: 1.45, description: '自動餵食設備維持穩定產量。' },
-    { level: 3, cost: 1200, boost: 1.6, description: '氣候調節雞舍，全年高產。' },
-  ],
-  pigPen: [
-    { level: 1, cost: 400, boost: 1.2, description: '泥土樂園讓豬豬更放鬆。' },
-    { level: 2, cost: 700, boost: 1.35, description: '增設噴霧與運動空間，提升肉質。' },
-  ],
-  pond: [
-    { level: 1, cost: 600, boost: 1.3, description: '自然池塘讓水鳥安心棲息。' },
-    { level: 2, cost: 950, boost: 1.45, description: '擴建浮台與遮蔭範圍。' },
-  ],
-};
+export {
+  ANIMAL_CARE_ACTIONS,
+  ANIMAL_CAPACITY_STEP,
+  BASE_ANIMAL_CAPACITY,
+  BASE_FARM_PLOTS,
+  BUILDING_UPGRADES,
+  FARM_EXPANSION_BATCH,
+  getAnimalHousingExpansionCost,
+  getFarmExpansionCost,
+  MAX_ANIMAL_CAPACITY,
+  MAX_FARM_PLOTS,
+} from './constants';
 
 export class GameEngine {
   constructor({ stateRef, setters, notifier }) {

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -731,35 +731,46 @@ export class GameEngine {
       return;
     }
 
+    const currentDay = Math.max(1, Math.floor(this.state.day ?? 1));
     this.setters.setMoney(prev => prev - (animal.price * purchasable));
+    let createdAnimals = [];
     this.setters.setAnimals(prev => {
       const prevList = Array.isArray(prev) ? prev : [];
       const baseIndex = prevList.filter(a => a.type === animalType).length;
       const timestamp = Date.now();
-      const traitKey = pickAnimalTraitKey(animalType) || 'steadfast';
-      const additions = Array.from({ length: purchasable }, (_, index) => ({
-        id: timestamp + index,
-        type: animalType,
-        happiness: animal.happiness,
-        hunger: 70,
-        lastFed: Date.now(),
-        sick: false,
-        sicknessDays: 0,
-        name: `${animal.name}${baseIndex + index + 1}`,
-        productReady: 0,
-        bond: 20,
-        cleanliness: 85,
-        careNeed: null,
-        careDays: 0,
-        lastCareTime: null,
-        trait: traitKey,
-      }));
-      const nextAnimals = [...prevList, ...additions];
+      createdAnimals = Array.from({ length: purchasable }, (_, index) => {
+        const traitKey = pickAnimalTraitKey(animalType) || 'steadfast';
+        return {
+          id: timestamp + index,
+          type: animalType,
+          happiness: animal.happiness,
+          hunger: 70,
+          lastFed: Date.now(),
+          sick: false,
+          sicknessDays: 0,
+          name: `${animal.name}${baseIndex + index + 1}`,
+          productReady: 0,
+          bond: 20,
+          cleanliness: 85,
+          careNeed: null,
+          careDays: 0,
+          lastCareTime: null,
+          trait: traitKey,
+          butcherableOnDay: currentDay,
+        };
+      });
+      const nextAnimals = [...prevList, ...createdAnimals];
       if (this.stateRef && this.stateRef.current) {
         this.stateRef.current.animals = nextAnimals;
       }
       return nextAnimals;
     });
+
+    if (createdAnimals.length > 0 && typeof this.setters.promptAnimalNaming === 'function') {
+      const firstNewArrival = createdAnimals[0];
+      const suggestedName = createdAnimals.length === 1 ? (firstNewArrival.name || '') : '';
+      this.setters.promptAnimalNaming(firstNewArrival.id, suggestedName);
+    }
 
     const label = purchasable > 1 ? `${purchasable} 隻${animal.name}` : `${animal.name}`;
     this.notify(`購買了 ${animal.emoji} ${label}！`, { type: 'success' });
@@ -775,6 +786,14 @@ export class GameEngine {
     const animal = animals.find(a => a.id === animalId);
     if (!animal) {
       this.notify('找不到這隻動物。', { type: 'error' });
+      return;
+    }
+
+    const currentDay = Math.max(1, Math.floor(this.state.day ?? 1));
+    if (typeof animal.butcherableOnDay === 'number' && currentDay < animal.butcherableOnDay) {
+      const remaining = animal.butcherableOnDay - currentDay;
+      const waitLabel = remaining === 1 ? '1 天' : `${remaining} 天`;
+      this.notify(`${animal.name} 還是幼年，再過 ${waitLabel} 才能處理牠喔！`, { type: 'warning' });
       return;
     }
 

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -11,6 +11,8 @@ import {
   MAX_ANIMAL_CAPACITY,
   MAX_FARM_PLOTS,
   pickAnimalTraitKey,
+  ENERGY_DRINK_RECOVERY,
+  getEnergyCapacity,
 } from './constants';
 
 export class GameEngine {
@@ -36,16 +38,33 @@ export class GameEngine {
     }
   }
 
-  consumeSupply(supplyType, { keepSelection = false } = {}) {
-    this.setters.setFarmSupplies(prev => {
-      const previous = prev || {};
-      const current = previous[supplyType] || 0;
-      return { ...previous, [supplyType]: Math.max(0, current - 1) };
-    });
+  getEnergyCap(overrides = {}) {
+    const levelValue = overrides.level ?? this.state.level ?? 1;
+    const buildingValue = overrides.buildings ?? this.state.buildings ?? {};
+    const normalizedLevel = Math.max(1, Math.floor(levelValue || 1));
+    return getEnergyCapacity(normalizedLevel, buildingValue);
+  }
 
-    if (!keepSelection) {
+  consumeSupply(supplyType, { keepSelection = false } = {}) {
+    let remaining = null;
+
+    if (typeof this.setters.setFarmSupplies === 'function') {
+      this.setters.setFarmSupplies(prev => {
+        const previous = prev || {};
+        const current = previous[supplyType] || 0;
+        const nextCount = Math.max(0, current - 1);
+        const updated = { ...previous, [supplyType]: nextCount };
+        this.stateRef.current.farmSupplies = updated;
+        remaining = nextCount;
+        return updated;
+      });
+    }
+
+    if (!keepSelection && typeof this.setters.setSelectedSupply === 'function') {
       this.setters.setSelectedSupply(null);
     }
+
+    return remaining;
   }
 
   getGreenhouseCount(buildings = this.state.buildings) {
@@ -312,10 +331,14 @@ export class GameEngine {
     }
 
     this.setters.setMoney(prev => prev - totalCost);
-    this.setters.setFarmSupplies(prev => {
-      const previous = prev || {};
-      return { ...previous, [supplyType]: (previous[supplyType] || 0) + quantity };
-    });
+    if (typeof this.setters.setFarmSupplies === 'function') {
+      this.setters.setFarmSupplies(prev => {
+        const previous = prev || {};
+        const updated = { ...previous, [supplyType]: (previous[supplyType] || 0) + quantity };
+        this.stateRef.current.farmSupplies = updated;
+        return updated;
+      });
+    }
     this.notify(`購買了 ${quantity} 份${supply.name}！`, { type: 'success' });
   }
 
@@ -413,6 +436,11 @@ export class GameEngine {
       return;
     }
 
+    if (supplyType === 'energyDrink') {
+      this.drinkEnergySupply();
+      return;
+    }
+
     const { selectedSupply } = this.state;
     if (selectedSupply === supplyType) {
       this.setters.setSelectedSupply(null);
@@ -432,6 +460,14 @@ export class GameEngine {
     if (!supply) {
       this.setters.setSelectedSupply(null);
       return false;
+    }
+
+    if (selectedSupply === 'energyDrink') {
+      this.notify('精力飲料請在體力面板飲用！', { type: 'info' });
+      if (typeof this.setters.setSelectedSupply === 'function') {
+        this.setters.setSelectedSupply(null);
+      }
+      return true;
     }
 
     if (selectedSupply === 'medicine') {
@@ -499,6 +535,39 @@ export class GameEngine {
     }
 
     return false;
+  }
+
+  drinkEnergySupply() {
+    const { farmSupplies, energy } = this.state;
+    const available = farmSupplies?.energyDrink || 0;
+    if (available <= 0) {
+      this.notify('沒有精力飲料，先到農務用品補貨吧！', { type: 'warning' });
+      return false;
+    }
+
+    const capacity = this.getEnergyCap();
+    if (energy >= capacity) {
+      this.notify('體力已經飽滿，暫時不需要補充。', { type: 'info' });
+      return false;
+    }
+
+    const recovery = Math.min(ENERGY_DRINK_RECOVERY, capacity - energy);
+    const remaining = this.consumeSupply('energyDrink', { keepSelection: true });
+    if (remaining == null) {
+      return false;
+    }
+
+    if (typeof this.setters.setEnergy === 'function') {
+      this.setters.setEnergy(prev => {
+        const base = typeof prev === 'number' ? prev : energy;
+        const next = Math.min(capacity, base + recovery);
+        this.stateRef.current.energy = next;
+        return next;
+      });
+    }
+
+    this.notify(`喝下精力飲料，恢復 ${recovery} 體力！`, { type: 'success' });
+    return true;
   }
 
   plantSeed(plotId) {
@@ -699,7 +768,11 @@ export class GameEngine {
       return nextFarm;
     });
 
-    this.setters.setEnergy(prev => Math.max(0, prev - energyCost));
+    this.setters.setEnergy(prev => {
+      const next = Math.max(0, prev - energyCost);
+      this.stateRef.current.energy = next;
+      return next;
+    });
     this.notify('澆水完成！', { type: 'success' });
   }
 

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -756,6 +756,7 @@ export class GameEngine {
           careDays: 0,
           lastCareTime: null,
           trait: traitKey,
+          age: 0,
           butcherableOnDay: currentDay,
         };
       });

--- a/src/game/engine/GameEngine.js
+++ b/src/game/engine/GameEngine.js
@@ -10,6 +10,7 @@ import {
   getFarmExpansionCost,
   MAX_ANIMAL_CAPACITY,
   MAX_FARM_PLOTS,
+  pickAnimalTraitKey,
 } from './constants';
 
 export class GameEngine {
@@ -735,6 +736,7 @@ export class GameEngine {
       const prevList = Array.isArray(prev) ? prev : [];
       const baseIndex = prevList.filter(a => a.type === animalType).length;
       const timestamp = Date.now();
+      const traitKey = pickAnimalTraitKey(animalType) || 'steadfast';
       const additions = Array.from({ length: purchasable }, (_, index) => ({
         id: timestamp + index,
         type: animalType,
@@ -750,8 +752,13 @@ export class GameEngine {
         careNeed: null,
         careDays: 0,
         lastCareTime: null,
+        trait: traitKey,
       }));
-      return [...prevList, ...additions];
+      const nextAnimals = [...prevList, ...additions];
+      if (this.stateRef && this.stateRef.current) {
+        this.stateRef.current.animals = nextAnimals;
+      }
+      return nextAnimals;
     });
 
     const label = purchasable > 1 ? `${purchasable} 隻${animal.name}` : `${animal.name}`;

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -6,7 +6,7 @@ import {
   MAX_FARM_PLOTS,
   BUILDING_UPGRADES,
   ANIMAL_CARE_ACTIONS,
-} from './GameEngine';
+} from './constants';
 
 const createDefaultInventory = () => {
   const inventory = {};

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -54,6 +54,15 @@ const createDefaultSupplies = () => ({
   medicine: 0,
 });
 
+const createDefaultLifetimeStats = () => ({
+  cropsPlanted: 0,
+});
+
+const withLifetimeStats = (stats) => ({
+  ...createDefaultLifetimeStats(),
+  ...(stats && typeof stats === 'object' ? stats : {}),
+});
+
 export class SaveManager {
   constructor({ stateRef, setters, notifier }) {
     this.stateRef = stateRef;
@@ -105,6 +114,7 @@ export class SaveManager {
       marketCommissions,
       commissionHistory,
       marketBoosts,
+      lifetimeStats,
     } = this.state;
 
     const safeFarm = Array.isArray(farm) ? farm : [];
@@ -149,8 +159,9 @@ export class SaveManager {
       marketCommissions: Array.isArray(marketCommissions) ? marketCommissions : [],
       commissionHistory: commissionHistory && typeof commissionHistory === 'object' ? { ...commissionHistory } : {},
       marketBoosts: marketBoosts && typeof marketBoosts === 'object' ? { ...marketBoosts } : {},
+      lifetimeStats: withLifetimeStats(lifetimeStats),
       saveTime: new Date().toISOString(),
-      version: '1.1',
+      version: '1.2',
     };
   }
 
@@ -195,6 +206,9 @@ export class SaveManager {
     const normalizedInventory = withInventoryDefaults(gameState.inventory);
     this.setters.setInventory(normalizedInventory);
     this.setters.setQuestLog(gameState.questLog ? { ...gameState.questLog } : {});
+    if (typeof this.setters.setLifetimeStats === 'function') {
+      this.setters.setLifetimeStats(withLifetimeStats(gameState.lifetimeStats));
+    }
     if (typeof this.setters.setDynamicQuests === 'function') {
       const dynamic = gameState.dynamicQuests && typeof gameState.dynamicQuests === 'object'
         ? { ...gameState.dynamicQuests }

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -8,6 +8,8 @@ import {
   ANIMAL_CARE_ACTIONS,
   ANIMAL_TRAIT_MAP,
   pickAnimalTraitKey,
+  ENERGY_RESTS_PER_DAY,
+  getEnergyCapacity,
 } from './constants';
 
 const createDefaultInventory = () => {
@@ -54,6 +56,7 @@ const createDefaultSupplies = () => ({
   fertilizer: 0,
   pesticide: 0,
   medicine: 0,
+  energyDrink: 0,
 });
 
 const createDefaultLifetimeStats = () => ({
@@ -117,6 +120,7 @@ export class SaveManager {
       commissionHistory,
       marketBoosts,
       lifetimeStats,
+      restCharges,
     } = this.state;
 
     const safeFarm = Array.isArray(farm) ? farm : [];
@@ -162,8 +166,9 @@ export class SaveManager {
       commissionHistory: commissionHistory && typeof commissionHistory === 'object' ? { ...commissionHistory } : {},
       marketBoosts: marketBoosts && typeof marketBoosts === 'object' ? { ...marketBoosts } : {},
       lifetimeStats: withLifetimeStats(lifetimeStats),
+      restCharges: Math.min(ENERGY_RESTS_PER_DAY, Math.max(0, restCharges ?? ENERGY_RESTS_PER_DAY)),
       saveTime: new Date().toISOString(),
-      version: '1.2',
+      version: '1.3',
     };
   }
 
@@ -197,7 +202,6 @@ export class SaveManager {
 
   applyState(gameState) {
     this.setters.setMoney(gameState.money);
-    this.setters.setEnergy(gameState.energy);
     this.setters.setLevel(gameState.level);
     this.setters.setExperience(gameState.experience);
     this.setters.setTime(gameState.time);
@@ -355,6 +359,15 @@ export class SaveManager {
       normalizedBuildings.greenhouse = desiredGreenhouseCount;
     } else {
       delete normalizedBuildings.greenhouse;
+    }
+
+    const normalizedLevel = Math.max(1, Math.floor(gameState.level || 1));
+    const energyCap = getEnergyCapacity(normalizedLevel, normalizedBuildings);
+    const requestedEnergy = typeof gameState.energy === 'number' ? gameState.energy : energyCap;
+    this.setters.setEnergy(Math.max(0, Math.min(energyCap, requestedEnergy)));
+    if (typeof this.setters.setRestCharges === 'function') {
+      const savedCharges = Math.max(0, Math.floor(gameState.restCharges ?? ENERGY_RESTS_PER_DAY));
+      this.setters.setRestCharges(Math.min(ENERGY_RESTS_PER_DAY, savedCharges));
     }
 
     this.setters.setFarm(normalizedFarm);

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -379,6 +379,7 @@ export class SaveManager {
           careNeed: animal.careNeed && ANIMAL_CARE_ACTIONS[animal.careNeed] ? animal.careNeed : null,
           careDays: Math.max(0, Math.floor(animal.careDays ?? 0)),
           lastCareTime: animal.lastCareTime ?? null,
+          age: Math.max(0, Math.floor(animal.age ?? 0)),
           butcherableOnDay: Math.max(1, Math.floor(animal.butcherableOnDay ?? 1)),
           trait: (() => {
             if (animal.trait && ANIMAL_TRAIT_MAP[animal.trait]) {

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -379,6 +379,7 @@ export class SaveManager {
           careNeed: animal.careNeed && ANIMAL_CARE_ACTIONS[animal.careNeed] ? animal.careNeed : null,
           careDays: Math.max(0, Math.floor(animal.careDays ?? 0)),
           lastCareTime: animal.lastCareTime ?? null,
+          butcherableOnDay: Math.max(1, Math.floor(animal.butcherableOnDay ?? 1)),
           trait: (() => {
             if (animal.trait && ANIMAL_TRAIT_MAP[animal.trait]) {
               return animal.trait;

--- a/src/game/engine/SaveManager.js
+++ b/src/game/engine/SaveManager.js
@@ -6,6 +6,8 @@ import {
   MAX_FARM_PLOTS,
   BUILDING_UPGRADES,
   ANIMAL_CARE_ACTIONS,
+  ANIMAL_TRAIT_MAP,
+  pickAnimalTraitKey,
 } from './constants';
 
 const createDefaultInventory = () => {
@@ -377,6 +379,13 @@ export class SaveManager {
           careNeed: animal.careNeed && ANIMAL_CARE_ACTIONS[animal.careNeed] ? animal.careNeed : null,
           careDays: Math.max(0, Math.floor(animal.careDays ?? 0)),
           lastCareTime: animal.lastCareTime ?? null,
+          trait: (() => {
+            if (animal.trait && ANIMAL_TRAIT_MAP[animal.trait]) {
+              return animal.trait;
+            }
+            const generated = pickAnimalTraitKey(animal.type);
+            return generated || 'steadfast';
+          })(),
         }))
       : [];
     this.setters.setAnimals(sanitizedAnimals);

--- a/src/game/engine/constants.js
+++ b/src/game/engine/constants.js
@@ -1,0 +1,98 @@
+import { FARM_SUPPLIES } from '../data/GameCatalog';
+
+export const BASE_FARM_PLOTS = 25;
+export const FARM_EXPANSION_BATCH = 1;
+export const MAX_FARM_PLOTS = 45;
+export const BASE_ANIMAL_CAPACITY = 6;
+export const ANIMAL_CAPACITY_STEP = 1;
+export const MAX_ANIMAL_CAPACITY = 24;
+
+export const getFarmExpansionCost = (currentPlotCount) => {
+  if (currentPlotCount >= MAX_FARM_PLOTS) {
+    return null;
+  }
+  const expansionsPurchased = Math.max(0, currentPlotCount - BASE_FARM_PLOTS);
+  return 1000 + (expansionsPurchased * 250);
+};
+
+export const getAnimalHousingExpansionCost = (currentCapacity) => {
+  if (currentCapacity >= MAX_ANIMAL_CAPACITY) {
+    return null;
+  }
+  return 2500;
+};
+
+export const BUILDING_UPGRADES = {
+  sprinkler: [
+    { level: 1, cost: 650, coverage: 12, manualWaterCost: 3, plantingDiscount: 3, description: '覆蓋 12 格農地，自動補水並減少播種體力。' },
+    { level: 2, cost: 900, coverage: 24, manualWaterCost: 2, plantingDiscount: 4, description: '覆蓋範圍擴大至 24 格，澆水幾乎不費力。' },
+    { level: 3, cost: 1400, coverage: 36, manualWaterCost: 1, plantingDiscount: 5, description: '灌溉到 36 格農地並極大幅度節省體力。' },
+    { level: 4, cost: 2200, coverage: MAX_FARM_PLOTS, manualWaterCost: 1, plantingDiscount: 6, description: '全區自動灌溉，維持土壤最佳濕度。' },
+  ],
+  silo: [
+    { level: 1, cost: 800, sellBonus: 0.05, description: '作物售價 +5%，減少腐壞。' },
+    { level: 2, cost: 1200, sellBonus: 0.1, description: '作物售價 +10%，可長期保存。' },
+    { level: 3, cost: 1800, sellBonus: 0.18, description: '作物售價 +18%，高效率倉儲。' },
+  ],
+  barn: [
+    { level: 1, cost: 1000, boost: 1.2, description: '提供牛羊穩定環境，提升產量。' },
+    { level: 2, cost: 1500, boost: 1.35, description: '擴增飼槽與溫控，提高品質。' },
+    { level: 3, cost: 2200, boost: 1.5, description: '頂級穀倉，讓牛羊更快樂。' },
+  ],
+  chickenCoop: [
+    { level: 1, cost: 500, boost: 1.3, description: '舒適雞舍，提升產蛋率。' },
+    { level: 2, cost: 850, boost: 1.45, description: '自動餵食設備維持穩定產量。' },
+    { level: 3, cost: 1200, boost: 1.6, description: '氣候調節雞舍，全年高產。' },
+  ],
+  pigPen: [
+    { level: 1, cost: 400, boost: 1.2, description: '泥土樂園讓豬豬更放鬆。' },
+    { level: 2, cost: 700, boost: 1.35, description: '增設噴霧與運動空間，提升肉質。' },
+  ],
+  pond: [
+    { level: 1, cost: 600, boost: 1.3, description: '自然池塘讓水鳥安心棲息。' },
+    { level: 2, cost: 950, boost: 1.45, description: '擴建浮台與遮蔭範圍。' },
+  ],
+};
+
+export const ANIMAL_CARE_ACTIONS = {
+  playtime: {
+    key: 'playtime',
+    label: '陪牠玩耍',
+    shortLabel: '陪玩',
+    needLabel: '想玩耍',
+    description: '與動物一起玩耍可以大幅提升幸福度與羈絆，但會稍微增加飢餓感。',
+    energyCost: 6,
+    happinessBoost: 18,
+    bondBoost: 14,
+    hungerImpact: 14,
+  },
+  grooming: {
+    key: 'grooming',
+    label: '梳洗打理',
+    shortLabel: '梳洗',
+    needLabel: '想梳洗',
+    description: '細心梳洗讓動物保持乾淨舒適，降低生病風險並增加羈絆。',
+    energyCost: 5,
+    happinessBoost: 12,
+    bondBoost: 10,
+    cleanlinessBoost: 22,
+    sootheSickness: true,
+  },
+  cleanPen: {
+    key: 'cleanPen',
+    label: '清理欄舍',
+    shortLabel: '清理',
+    needLabel: '需要清理',
+    description: '整理環境讓欄舍更乾淨，恢復整潔度並讓動物更安心。',
+    energyCost: 7,
+    happinessBoost: 8,
+    bondBoost: 8,
+    cleanlinessBoost: 28,
+  },
+};
+
+export const SUPPLY_PURCHASE_LIMITS = {
+  fertilizer: FARM_SUPPLIES.fertilizer?.maxPurchase ?? 99,
+  pesticide: FARM_SUPPLIES.pesticide?.maxPurchase ?? 99,
+  medicine: FARM_SUPPLIES.medicine?.maxPurchase ?? 99,
+};

--- a/src/game/engine/constants.js
+++ b/src/game/engine/constants.js
@@ -4,6 +4,7 @@ export const MAX_FARM_PLOTS = 45;
 export const BASE_ANIMAL_CAPACITY = 6;
 export const ANIMAL_CAPACITY_STEP = 1;
 export const MAX_ANIMAL_CAPACITY = 24;
+export const ANIMAL_MIN_BUTCHER_AGE_DAYS = 3;
 
 export const getFarmExpansionCost = (currentPlotCount) => {
   if (currentPlotCount >= MAX_FARM_PLOTS) {

--- a/src/game/engine/constants.js
+++ b/src/game/engine/constants.js
@@ -6,6 +6,56 @@ export const ANIMAL_CAPACITY_STEP = 1;
 export const MAX_ANIMAL_CAPACITY = 24;
 export const ANIMAL_MIN_BUTCHER_AGE_DAYS = 3;
 
+export const BASE_ENERGY_CAP = 100;
+export const ENERGY_CAP_PER_LEVEL = 5;
+export const ENERGY_CAP_MAX = 160;
+export const ENERGY_RESTS_PER_DAY = 2;
+export const ENERGY_DRINK_RECOVERY = 28;
+
+const ENERGY_BUILDING_BONUS = {
+  pond: 6,
+  windmill: 8,
+  barn: 4,
+};
+
+const resolveBuildingLevel = (buildings, key) => {
+  if (!buildings) {
+    return 0;
+  }
+
+  const raw = buildings[key];
+  if (typeof raw === 'number') {
+    return Math.max(0, Math.floor(raw));
+  }
+
+  if (raw && typeof raw === 'object' && typeof raw.level === 'number') {
+    return Math.max(0, Math.floor(raw.level));
+  }
+
+  return raw ? 1 : 0;
+};
+
+export const getEnergyCapacity = (level = 1, buildings = {}) => {
+  const normalizedLevel = Math.max(1, Math.floor(level));
+  const baseCap = BASE_ENERGY_CAP + Math.max(0, normalizedLevel - 1) * ENERGY_CAP_PER_LEVEL;
+
+  const buildingBonus = Object.entries(ENERGY_BUILDING_BONUS).reduce((sum, [key, bonus]) => {
+    const ownedLevel = resolveBuildingLevel(buildings, key);
+    if (ownedLevel <= 0) {
+      return sum;
+    }
+    return sum + bonus * ownedLevel;
+  }, 0);
+
+  return Math.min(ENERGY_CAP_MAX, baseCap + buildingBonus);
+};
+
+export const getRestRecoveryAmount = (level = 1, buildings = {}) => {
+  const capacity = getEnergyCapacity(level, buildings);
+  const quarter = Math.round(capacity * 0.25);
+  return Math.max(18, quarter);
+};
+
 export const getFarmExpansionCost = (currentPlotCount) => {
   if (currentPlotCount >= MAX_FARM_PLOTS) {
     return null;

--- a/src/game/engine/constants.js
+++ b/src/game/engine/constants.js
@@ -88,3 +88,74 @@ export const ANIMAL_CARE_ACTIONS = {
     cleanlinessBoost: 28,
   },
 };
+
+export const ANIMAL_TRAITS = [
+  {
+    key: 'steadfast',
+    name: '穩健個性',
+    description: '性格穩重，沒有額外效果，容易照顧。',
+    weight: 2,
+    modifiers: {},
+  },
+  {
+    key: 'energetic',
+    name: '活力充沛',
+    description: '羈絆成長較快，但食量也比較大，容易感到飢餓。',
+    weight: 1,
+    modifiers: {
+      hungerLoss: 1.25,
+      bondDecay: 0.85,
+      production: 1.1,
+    },
+  },
+  {
+    key: 'gentle',
+    name: '溫馴體質',
+    description: '抵抗力較高、飢餓下降慢一些，但產量稍微普通。',
+    weight: 1,
+    modifiers: {
+      hungerLoss: 0.9,
+      sicknessRisk: 0.7,
+      production: 0.95,
+    },
+  },
+  {
+    key: 'diligent',
+    name: '勤勞小幫手',
+    description: '產量更高、欄舍保持得較乾淨，但幸福度下降稍快。',
+    weight: 1,
+    modifiers: {
+      production: 1.2,
+      cleanlinessDecay: 0.85,
+      happinessDecay: 1.1,
+    },
+  },
+  {
+    key: 'gourmet',
+    name: '挑嘴吃貨',
+    description: '對食物要求高，餓肚子時情緒跌得更快，但餵飽後產量提升。',
+    weight: 1,
+    modifiers: {
+      hungerLoss: 1.3,
+      hungerMoodPenalty: 1.25,
+      production: 1.15,
+    },
+  },
+];
+
+export const ANIMAL_TRAIT_MAP = ANIMAL_TRAITS.reduce((map, trait) => {
+  map[trait.key] = trait;
+  return map;
+}, {});
+
+export const pickAnimalTraitKey = (animalType) => {
+  const pool = ANIMAL_TRAITS.filter(trait => !trait.types || trait.types.includes(animalType));
+  const source = pool.length > 0 ? pool : ANIMAL_TRAITS;
+  const expanded = source.flatMap(trait => Array(Math.max(1, Math.floor(trait.weight || 1))).fill(trait));
+  const selection = expanded.length > 0 ? expanded : source;
+  if (selection.length === 0) {
+    return null;
+  }
+  const choice = selection[Math.floor(Math.random() * selection.length)];
+  return choice?.key || null;
+};

--- a/src/game/engine/constants.js
+++ b/src/game/engine/constants.js
@@ -1,5 +1,3 @@
-import { FARM_SUPPLIES } from '../data/GameCatalog';
-
 export const BASE_FARM_PLOTS = 25;
 export const FARM_EXPANSION_BATCH = 1;
 export const MAX_FARM_PLOTS = 45;
@@ -89,10 +87,4 @@ export const ANIMAL_CARE_ACTIONS = {
     bondBoost: 8,
     cleanlinessBoost: 28,
   },
-};
-
-export const SUPPLY_PURCHASE_LIMITS = {
-  fertilizer: FARM_SUPPLIES.fertilizer?.maxPurchase ?? 99,
-  pesticide: FARM_SUPPLIES.pesticide?.maxPurchase ?? 99,
-  medicine: FARM_SUPPLIES.medicine?.maxPurchase ?? 99,
 };


### PR DESCRIPTION
## Summary
- track lifetime crop planting counts and persist them across saves
- add planter achievement tiers for 100, 500, and 1000 crops planted
- hook planting flow and achievement unlock logic into the new lifetime stats

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d49283e1b48329b016090fe1019068